### PR TITLE
Add txn ref metadata to all requests; add to Cybs.

### DIFF
--- a/gateways/cybersource/cybersource.go
+++ b/gateways/cybersource/cybersource.go
@@ -53,7 +53,9 @@ func NewWithHttpClient(env Environment, merchantID string, sharedSecretKeyID str
 }
 
 // Authorize make a payment authorization request to CyberSource for the given payment details. If successful, the
-// authorization response will be returned.
+// authorization response will be returned. If level 3 data is present in the authorization request and contains
+// a CustomerReference, the ClientReferenceInformation of this request will be overridden in order to to match the
+// level 3 data's CustomerReference.
 func (client *CybersourceClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
 	cybersourceAuthRequest, err := buildAuthRequest(request)
 	if err != nil {

--- a/gateways/cybersource/request_builders.go
+++ b/gateways/cybersource/request_builders.go
@@ -42,6 +42,7 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest) (*Request, error)
 			},
 		},
 	}
+	// If level 3 data is present, and ClientReferenceInformation in that data exists, it will override this.
 	if authRequest.ClientTransactionReference != nil {
 		request.ClientReferenceInformation = &ClientReferenceInformation{
 			Code: *authRequest.ClientTransactionReference,
@@ -91,12 +92,22 @@ func buildCaptureRequest(captureRequest *sleet.CaptureRequest) (*Request, error)
 			},
 		},
 	}
+	if captureRequest.ClientTransactionReference != nil {
+		request.ClientReferenceInformation = &ClientReferenceInformation{
+			Code: *captureRequest.ClientTransactionReference,
+		}
+	}
 	return request, nil
 }
 
 func buildVoidRequest(voidRequest *sleet.VoidRequest) (*Request, error) {
 	// Maybe add reason / more details, but for now nothing
 	request := &Request{}
+	if voidRequest.ClientTransactionReference != nil {
+		request.ClientReferenceInformation = &ClientReferenceInformation{
+			Code: *voidRequest.ClientTransactionReference,
+		}
+	}
 	return request, nil
 }
 
@@ -109,6 +120,11 @@ func buildRefundRequest(refundRequest *sleet.RefundRequest) (*Request, error) {
 				Currency: refundRequest.Amount.Currency,
 			},
 		},
+	}
+	if refundRequest.ClientTransactionReference != nil {
+		request.ClientReferenceInformation = &ClientReferenceInformation{
+			Code: *refundRequest.ClientTransactionReference,
+		}
 	}
 	return request, nil
 }

--- a/gateways/cybersource/types.go
+++ b/gateways/cybersource/types.go
@@ -1,7 +1,5 @@
 package cybersource
 
-// TODO add ClientReferenceInformation.Code to Sleet request
-
 // Should we just combine these to one Request and have pointers?
 type Request struct {
 	ClientReferenceInformation *ClientReferenceInformation `json:"clientReferenceInformation,omitempty"`

--- a/types.go
+++ b/types.go
@@ -61,7 +61,7 @@ type AuthorizationRequest struct {
 	CreditCard                 *CreditCard
 	BillingAddress             *BillingAddress
 	Level3Data                 *Level3Data
-	ClientTransactionReference *string // pass in an id of the transaction from any client
+	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
 	Options                    map[string]interface{}
 }
 
@@ -81,8 +81,9 @@ type AuthorizationResponse struct {
 }
 
 type CaptureRequest struct {
-	Amount               *Amount
-	TransactionReference string
+	Amount                     *Amount
+	TransactionReference       string
+	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
 }
 
 type CaptureResponse struct {
@@ -92,7 +93,8 @@ type CaptureResponse struct {
 }
 
 type VoidRequest struct {
-	TransactionReference string
+	TransactionReference       string
+	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
 }
 
 type VoidResponse struct {
@@ -102,9 +104,10 @@ type VoidResponse struct {
 }
 
 type RefundRequest struct {
-	Amount               *Amount
-	TransactionReference string
-	Options              map[string]interface{}
+	Amount                     *Amount
+	TransactionReference       string
+	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
+	Options                    map[string]interface{}
 }
 
 type RefundResponse struct {


### PR DESCRIPTION
Adds transaction reference metadata field to all requests (previously it was only in auth requests, now added to capture, refund, and void). Also incorporates this reference field in all CyberSource requests.