### PR TITLE
Remove duplicate CI steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,6 @@ jobs:
           command: |
             go build -v ./...
       - run:
-          name: Unit Test
-          command: |
-            go test -v ./integration-tests/*.go
-      - run:
           name: Integration Test
           command: |
             go test -v ./integration-tests/*.go


### PR DESCRIPTION
`Unit Test` is actually doing same thing as `Integration Test` step. Until the day we add unit test we can remove this step