### PR TITLE
[nmi] return response text for declines

### DIFF
--- a/gateways/nmi/nmi.go
+++ b/gateways/nmi/nmi.go
@@ -49,9 +49,11 @@ func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.
 	// "2" means declined and "3" means bad request
 	if nmiResponse.Response != "1" {
 		return &sleet.AuthorizationResponse{
-			Success:   false,
-			Response:  nmiResponse.Response,
-			ErrorCode: nmiResponse.ResponseCode,
+			Success: false,
+			// transaction references are sometimes returned in ResponseText for error responses
+			TransactionReference: nmiResponse.ResponseText,
+			Response:             nmiResponse.Response,
+			ErrorCode:            nmiResponse.ResponseCode,
 		}, nil
 	}
 


### PR DESCRIPTION
Transaction references are sometimes returned in the response text when the transaction is declined. This reference lets merchants reach out to NMI to get more information about the decline. 