### PR TITLE
[adyen] saving new customer credit card information

### DIFF
--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -22,8 +22,7 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 			"expiryYear":  strconv.Itoa(authRequest.CreditCard.ExpirationYear),
 			"holderName":  authRequest.CreditCard.FirstName + " " + authRequest.CreditCard.LastName,
 		},
-		MerchantAccount:          merchantAccount,
-		RecurringProcessingModel: "CardOnFile",
+		MerchantAccount: merchantAccount,
 	}
 
 	if authRequest.BillingAddress != nil {
@@ -47,16 +46,25 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 		}
 		request.PaymentMethod["brand"] = authRequest.CreditCard.Network.String()
 		request.PaymentMethod["type"] = "networkToken"
+		request.RecurringProcessingModel = "CardOnFile"
 		request.ShopperInteraction = "Ecommerce"
 	} else if authRequest.CreditCard.CVV != "" {
 		// New customer credit card request
 		request.PaymentMethod["cvc"] = authRequest.CreditCard.CVV
 		request.PaymentMethod["type"] = "scheme"
 		request.ShopperInteraction = "Ecommerce"
-		request.StorePaymentMethod = true
+		if authRequest.CreditCard.Save {
+			// Customer opts in to saving card details
+			request.RecurringProcessingModel = "CardOnFile"
+			request.StorePaymentMethod = true
+		} else {
+			// Customer opts out of saving card details
+			request.StorePaymentMethod = false
+		}
 	} else {
 		// Existing customer credit card request
 		request.PaymentMethod["type"] = "scheme"
+		request.RecurringProcessingModel = "CardOnFile"
 		request.ShopperInteraction = "ContAuth"
 	}
 

--- a/integration-tests/adyen_test.go
+++ b/integration-tests/adyen_test.go
@@ -149,6 +149,23 @@ func TestAdyenRechargeAuth(t *testing.T) {
 	}
 }
 
+// TestAdyenOneTimeAuth
+//
+// This should successfully create an authorization on Adyen for customer that does not want his/her card saved
+func TestAdyenOneTimeAuth(t *testing.T) {
+	client := adyen.NewClient(getEnv("ADYEN_ACCOUNT"), getEnv("ADYEN_KEY"), "", common.Sandbox)
+	request := sleet_testing.BaseAuthorizationRequest()
+	request.CreditCard.Save = false
+	auth, err := client.Authorize(request)
+	if err != nil {
+		t.Error("Authorize request should not have failed")
+	}
+
+	if !auth.Success {
+		t.Error("Resulting auth should have been successful")
+	}
+}
+
 // TestAdyenAuthFullCapture
 //
 // This should successfully create an authorization on Adyen then Capture for full amount

--- a/testing/auth_request.go
+++ b/testing/auth_request.go
@@ -26,6 +26,7 @@ func BaseAuthorizationRequest() *sleet.AuthorizationRequest {
 		ExpirationMonth: 10,
 		ExpirationYear:  2020,
 		CVV:             "737",
+		Save:            true,
 	}
 	reference := randomdata.Letters(10)
 	return &sleet.AuthorizationRequest{Amount: amount, CreditCard: &card, BillingAddress: &address, ClientTransactionReference: &reference}

--- a/types.go
+++ b/types.go
@@ -37,6 +37,7 @@ type CreditCard struct {
 	ExpirationYear  int
 	CVV             string
 	Network         CreditCardNetwork
+	Save            bool
 }
 
 // LineItem is used for Level3 Processing if enabled (not default). Specifies information per item in the order
@@ -69,14 +70,14 @@ type Level3Data struct {
 // Note: Only credit cards are supported
 // Note: Options is a generic key-value pair that can be used to provide additional information to PsP
 type AuthorizationRequest struct {
-	Amount                        Amount
-	CreditCard                    *CreditCard
-	BillingAddress                *BillingAddress
-	Level3Data                    *Level3Data
-	ClientTransactionReference    *string // Custom transaction reference metadata that will be associated with this request
-	Channel                       string  // for Psps that track the sales channel
-	Cryptogram                    string  // for Network Tokenization methods
-	ECI                           string  // E-Commerce Indicator (can be used for Network Tokenization as well)
+	Amount                     Amount
+	CreditCard                 *CreditCard
+	BillingAddress             *BillingAddress
+	Level3Data                 *Level3Data
+	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
+	Channel                    string  // for Psps that track the sales channel
+	Cryptogram                 string  // for Network Tokenization methods
+	ECI                        string  // E-Commerce Indicator (can be used for Network Tokenization as well)
 
 	// For Card on File transactions we want to store the various different types (initial cof, initial recurring, etc)
 	// If we are in a recurring situation, then we can use the PreviousExternalTransactionID as part of the auth request

--- a/types.go
+++ b/types.go
@@ -37,7 +37,7 @@ type CreditCard struct {
 	ExpirationYear  int
 	CVV             string
 	Network         CreditCardNetwork
-	Save            bool
+	Save            bool // indicates if customer wants to save their credit card details
 }
 
 // LineItem is used for Level3 Processing if enabled (not default). Specifies information per item in the order


### PR DESCRIPTION
In the Adyen auth request, differentiate between new customers who do want to save their credit card information and new customer who do not want to save their credit card information.