### PR TITLE
[nmi] return response_code rather than response

### DIFF
--- a/gateways/nmi/nmi.go
+++ b/gateways/nmi/nmi.go
@@ -50,7 +50,7 @@ func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.
 	if nmiResponse.Response != "1" {
 		return &sleet.AuthorizationResponse{
 			Success:   false,
-			Response:  nmiResponse.Response,
+			Response:  nmiResponse.ResponseCode,
 			ErrorCode: nmiResponse.ResponseCode,
 		}, nil
 	}
@@ -60,7 +60,7 @@ func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.
 		TransactionReference: nmiResponse.TransactionID,
 		AvsResult:            sleet.AVSResponseUnknown,
 		CvvResult:            sleet.CVVResponseUnknown,
-		Response:             nmiResponse.Response,
+		Response:             nmiResponse.ResponseCode,
 		AvsResultRaw:         nmiResponse.AVSResponseCode,
 		CvvResultRaw:         nmiResponse.CVVResponseCode,
 	}, nil


### PR DESCRIPTION
The NMI "response" Transaction Response Variable is only 1, 2, or 3 so it doesn't provide much information about transaction declines. The "response_code" Transaction Response Variable ([values](https://secure.networkmerchants.com/gw/merchants/resources/integration/integration_portal.php#dp_appendix_3)) provides much more information about declines.