### PR TITLE
[adyen] use Adyen specific names for credit card brands

### DIFF
--- a/credit_card_network.go
+++ b/credit_card_network.go
@@ -11,17 +11,3 @@ const (
 	CreditCardNetworkJcb
 	CreditCardNetworkUnionpay
 )
-
-var creditCardNetworkToString = map[CreditCardNetwork]string{
-	CreditCardNetworkUnknown:    "Unknown",
-	CreditCardNetworkVisa:       "Visa",
-	CreditCardNetworkMastercard: "Mastercard",
-	CreditCardNetworkAmex:       "Amex",
-	CreditCardNetworkDiscover:   "Discover",
-	CreditCardNetworkJcb:        "Jcb",
-	CreditCardNetworkUnionpay:   "Unionpay",
-}
-
-func (code CreditCardNetwork) String() string {
-	return creditCardNetworkToString[code]
-}

--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -52,6 +52,16 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 	return request
 }
 
+var creditCardNetworkToString = map[sleet.CreditCardNetwork]string{
+	sleet.CreditCardNetworkUnknown:    "unknown",
+	sleet.CreditCardNetworkVisa:       "visa",
+	sleet.CreditCardNetworkMastercard: "mc",
+	sleet.CreditCardNetworkAmex:       "amex",
+	sleet.CreditCardNetworkDiscover:   "discover",
+	sleet.CreditCardNetworkJcb:        "jcb",
+	sleet.CreditCardNetworkUnionpay:   "unionpay",
+}
+
 // addPaymentSpecificFields adds fields to the Adyen Payment request that are dependent on the payment method
 func addPaymentSpecificFields(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
 	if authRequest.Cryptogram != "" && authRequest.ECI != "" {
@@ -62,7 +72,10 @@ func addPaymentSpecificFields(authRequest *sleet.AuthorizationRequest, request *
 			DirectoryResponse:      "Y",
 			Eci:                    authRequest.ECI,
 		}
-		request.PaymentMethod["brand"] = authRequest.CreditCard.Network.String()
+		brand, ok := creditCardNetworkToString[authRequest.CreditCard.Network]
+		if ok {
+			request.PaymentMethod["brand"] = brand
+		}
 		request.PaymentMethod["type"] = "networkToken"
 		request.RecurringProcessingModel = "CardOnFile"
 		request.ShopperInteraction = "Ecommerce"

--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -53,7 +53,6 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 }
 
 var creditCardNetworkToString = map[sleet.CreditCardNetwork]string{
-	sleet.CreditCardNetworkUnknown:    "unknown",
 	sleet.CreditCardNetworkVisa:       "visa",
 	sleet.CreditCardNetworkMastercard: "mc",
 	sleet.CreditCardNetworkAmex:       "amex",


### PR DESCRIPTION
`visa` and `mc` are the only confirmed names ([doc](https://docs.adyen.com/checkout/network-tokenization#make-a-one-off-payment-or-the-first-payment-in-a-subscription)). Will email Pete to ask about names for other cc brands.