### PR TITLE
Add MerchantOrderReference to auth request

### DIFF
--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -29,6 +29,7 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 			"holderName":  authRequest.CreditCard.FirstName + " " + authRequest.CreditCard.LastName,
 		},
 		MerchantAccount: merchantAccount,
+		MerchantOrderReference: authRequest.MerchantOrderReference,
 	}
 
 	if authRequest.BillingAddress != nil {

--- a/types.go
+++ b/types.go
@@ -78,6 +78,7 @@ type AuthorizationRequest struct {
 	Channel                    string  // for Psps that track the sales channel
 	Cryptogram                 string  // for Network Tokenization methods
 	ECI                        string  // E-Commerce Indicator (can be used for Network Tokenization as well)
+	MerchantOrderReference     string  // Similar to ClientTransactionReference but specifically if we want to store the shopping cart order id
 
 	// For Card on File transactions we want to store the various different types (initial cof, initial recurring, etc)
 	// If we are in a recurring situation, then we can use the PreviousExternalTransactionID as part of the auth request


### PR DESCRIPTION
I've noticed this with Stripe as well where there is some concept of the shopping carts order reference and maybe Bolt's transaction reference so lets also pass along the MerchantOrderReference and use that for Adyen