### PR TITLE
Convert switch statements in transaction.go to map

### DIFF
--- a/gateways/adyen/adyen.go
+++ b/gateways/adyen/adyen.go
@@ -69,13 +69,13 @@ func (client *AdyenClient) Authorize(request *sleet.AuthorizationRequest) (*slee
 		values, ok := result.AdditionalData.(map[string]interface{})
 		if ok {
 			if avs, isPresent := values["avsResult"]; isPresent {
-				response.AvsResult = translateAvs(avs.(string))
+				response.AvsResult = translateAvs(AVSResponse(avs.(string)))
 			}
 			if avsRaw, isPresent := values["avsResultRaw"]; isPresent {
 				response.AvsResultRaw = avsRaw.(string)
 			}
 			if cvc, isPresent := values["cvcResult"]; isPresent {
-				response.CvvResult = translateCvv(cvc.(string))
+				response.CvvResult = translateCvv(CVCResult(cvc.(string)))
 			}
 			if cvcRaw, isPresent := values["cvcResultRaw"]; isPresent {
 				response.CvvResultRaw = cvcRaw.(string)

--- a/gateways/adyen/translation.go
+++ b/gateways/adyen/translation.go
@@ -54,68 +54,64 @@ const (
 	CVCResult6 CVCResult = "6 No CVC/CVV provided"
 )
 
+var cvvMap = map[CVCResult]sleet.CVVResponse{
+	CVCResult0: sleet.CVVResponseUnknown,
+	CVCResult1: sleet.CVVResponseMatch,
+	CVCResult2: sleet.CVVResponseNoMatch,
+	CVCResult3: sleet.CVVResponseNotProcessed,
+	CVCResult4: sleet.CVVResponseRequiredButMissing,
+	CVCResult5: sleet.CVVResponseUnsupported,
+	CVCResult6: sleet.CVVResponseNotProcessed,
+}
+
+var avsMap = map[AVSResponse]sleet.AVSResponse{
+	AVSResponse0:  sleet.AVSResponseUnknown,
+	AVSResponse1:  sleet.AVSResponseZipNoMatchAddressMatch,
+	AVSResponse2:  sleet.AVSResponseNoMatch,
+	AVSResponse7:  sleet.AVSResponseNoMatch,
+	AVSResponse10: sleet.AVSResponseNoMatch,
+	AVSResponse13: sleet.AVSResponseNoMatch,
+	AVSResponse16: sleet.AVSResponseNoMatch,
+	AVSResponse17: sleet.AVSResponseNoMatch,
+	AVSResponse3:  sleet.AVSResponseUnsupported,
+	AVSResponse4:  sleet.AVSResponseUnsupported,
+	AVSResponse5:  sleet.AVSResponseSkipped,
+	AVSResponse8:  sleet.AVSResponseSkipped,
+	AVSResponse11: sleet.AVSResponseSkipped,
+	AVSResponse18: sleet.AVSResponseSkipped,
+	AVSResponse6:  sleet.AVSResponseZip9MatchAddressNoMatch,
+	AVSResponse9:  sleet.AVSResponseZipUnverifiedAddressMatch,
+	AVSResponse12: sleet.AVSResponseZipUnverifiedAddressMatch,
+	AVSResponse14: sleet.AVSResponseZipMatchAddressUnverified,
+	AVSResponse15: sleet.AVSResponseZipMatchAddressUnverified,
+	AVSResponse19: sleet.AVSResponseNameMatchZipMatchAddressNoMatch,
+	AVSResponse20: sleet.AVSResponseNameMatchZipMatchAddressMatch,
+	AVSResponse21: sleet.AVSResponseNameMatchZipNoMatchAddressMatch,
+	AVSResponse22: sleet.AVSResponseNameMatchZipNoMatchAddressNoMatch,
+	AVSResponse23: sleet.AVSResponseNameNoMatchZipMatch,
+	AVSResponse24: sleet.AVSResponseNameNoMatchZipMatchAddressMatch,
+	AVSResponse25: sleet.AVSResponseNameNoMatchAddressMatch,
+	AVSResponse26: sleet.AVSResponseNameMatchZipNoMatchAddressNoMatch,
+}
+
 // translateCvv converts a Adyen CVV response code to its equivalent Sleet standard code.
 // Note: Adyen already does a translation so this is a translation from Adyen to Sleet standard
 // https://docs.com/development-resources/test-cards/cvc-cvv-result-testing
-func translateCvv(adyenCVC string) sleet.CVVResponse {
-	switch CVCResult(adyenCVC) {
-	case CVCResult0:
-		return sleet.CVVResponseUnknown
-	case CVCResult1:
-		return sleet.CVVResponseMatch
-	case CVCResult2:
-		return sleet.CVVResponseNoMatch
-	case CVCResult3:
-		return sleet.CVVResponseNotProcessed
-	case CVCResult4:
-		return sleet.CVVResponseRequiredButMissing
-	case CVCResult5:
-		return sleet.CVVResponseUnsupported
-	case CVCResult6:
-		return sleet.CVVResponseNotProcessed
-	default:
+func translateCvv(adyenCVC CVCResult) sleet.CVVResponse {
+	sleetCode, ok := cvvMap[adyenCVC]
+	if !ok {
 		return sleet.CVVResponseUnknown
 	}
+	return sleetCode
 }
 
 // translateAvs converts a Adyen AVS response code to its equivalent Sleet standard code.
 // Note: Adyen already does some level of translation so we are relying on their docs here:
 // https://docs.com/risk-management/avs-checks
-func translateAvs(adyenAVS string) sleet.AVSResponse {
-	switch AVSResponse(adyenAVS) {
-	case AVSResponse0:
-		return sleet.AVSResponseUnknown
-	case AVSResponse1:
-		return sleet.AVSResponseZipNoMatchAddressMatch
-	case AVSResponse2, AVSResponse7, AVSResponse10, AVSResponse13, AVSResponse16, AVSResponse17:
-		return sleet.AVSResponseNoMatch
-	case AVSResponse3, AVSResponse4:
-		return sleet.AVSResponseUnsupported
-	case AVSResponse5, AVSResponse8, AVSResponse11, AVSResponse18:
-		return sleet.AVSResponseSkipped
-	case AVSResponse6:
-		return sleet.AVSResponseZip9MatchAddressNoMatch
-	case AVSResponse9, AVSResponse12:
-		return sleet.AVSResponseZipUnverifiedAddressMatch
-	case AVSResponse14, AVSResponse15:
-		return sleet.AVSResponseZipMatchAddressUnverified
-	case AVSResponse19:
-		return sleet.AVSResponseNameMatchZipMatchAddressNoMatch
-	case AVSResponse20:
-		return sleet.AVSResponseNameMatchZipMatchAddressMatch
-	case AVSResponse21:
-		return sleet.AVSResponseNameMatchZipNoMatchAddressMatch
-	case AVSResponse22:
-		return sleet.AVSResponseNameMatchZipNoMatchAddressNoMatch
-	case AVSResponse23:
-		return sleet.AVSResponseNameNoMatchZipMatch
-	case AVSResponse24:
-		return sleet.AVSResponseNameNoMatchZipMatchAddressMatch
-	case AVSResponse25:
-		return sleet.AVSResponseNameNoMatchAddressMatch
-	case AVSResponse26:
-		return sleet.AVSResponseNameMatchZipNoMatchAddressNoMatch
-	default:
+func translateAvs(adyenAVS AVSResponse) sleet.AVSResponse {
+	sleetCode, ok := avsMap[adyenAVS]
+	if !ok {
 		return sleet.AVSResponseUnknown
 	}
+	return sleetCode
 }

--- a/gateways/cybersource/translation.go
+++ b/gateways/cybersource/translation.go
@@ -2,74 +2,66 @@ package cybersource
 
 import "github.com/BoltApp/sleet"
 
+// Codes taken from: https://support.cybersource.com/s/article/Where-can-I-find-a-list-of-all-the-reply-codes-for-CVV-CVN-validation
+var cvvMap = map[string]sleet.CVVResponse{
+	"":  sleet.CVVResponseNoResponse,
+	"3": sleet.CVVResponseNoResponse,
+	"I": sleet.CVVResponseError,
+	"U": sleet.CVVResponseUnsupported,
+	"X": sleet.CVVResponseUnsupported,
+	"1": sleet.CVVResponseUnsupported,
+	"M": sleet.CVVResponseMatch,
+	"N": sleet.CVVResponseNoMatch,
+	"P": sleet.CVVResponseNotProcessed,
+	"S": sleet.CVVResponseRequiredButMissing,
+	"D": sleet.CVVResponseSuspicious,
+	"2": sleet.CVVResponseUnknown,
+}
+
+// Codes taken from: https://support.cybersource.com/s/article/AVS-Address-Verification-System-Results
+var avsMap = map[string]sleet.AVSResponse{
+	"A": sleet.AVSResponseZipNoMatchAddressMatch,
+	"B": sleet.AVSResponseNonUsZipUnverifiedAddressMatch,
+	"C": sleet.AVSResponseNonUsZipNoMatchAddressNoMatch,
+	"D": sleet.AVSResponseNonUsZipMatchAddressMatch,
+	"M": sleet.AVSResponseNonUsZipMatchAddressMatch,
+	"E": sleet.AVSResponseUnsupported,
+	"G": sleet.AVSResponseUnsupported,
+	"S": sleet.AVSResponseUnsupported,
+	"U": sleet.AVSResponseUnsupported,
+	"1": sleet.AVSResponseUnsupported,
+	"F": sleet.AVSResponseNameNoMatch,
+	"H": sleet.AVSResponseNameNoMatch,
+	"I": sleet.AVSResponseSkipped,
+	"K": sleet.AVSResponseNameMatchZipNoMatchAddressNoMatch,
+	"L": sleet.AVSResponseNameMatchZipMatchAddressNoMatch,
+	"N": sleet.AVSResponseNoMatch,
+	"O": sleet.AVSResponseNameMatchZipNoMatchAddressMatch,
+	"P": sleet.AVSResponseZipMatchAddressUnverified,
+	"R": sleet.AVSResponseError,
+	"T": sleet.AVSResponseNameNoMatchAddressMatch,
+	"V": sleet.AVSResponseMatch,
+	"W": sleet.AVSResponseZip9MatchAddressNoMatch,
+	"X": sleet.AVSResponseZip9MatchAddressMatch,
+	"Y": sleet.AVSResponseZip5MatchAddressMatch,
+	"Z": sleet.AVSResponseZip5MatchAddressNoMatch,
+	"2": sleet.AVSResponseUnknown,
+}
+
 // translateCvv converts a CyberSource CVV response code to its equivalent Sleet standard code.
 func translateCvv(rawCvv string) sleet.CVVResponse {
-	// Codes taken from: https://support.cybersource.com/s/article/Where-can-I-find-a-list-of-all-the-reply-codes-for-CVV-CVN-validation
-	switch rawCvv {
-	case "", "3":
-		return sleet.CVVResponseNoResponse
-	case "I":
-		return sleet.CVVResponseError
-	case "U", "X", "1":
-		return sleet.CVVResponseUnsupported
-	case "M":
-		return sleet.CVVResponseMatch
-	case "N":
-		return sleet.CVVResponseNoMatch
-	case "P":
-		return sleet.CVVResponseNotProcessed
-	case "S":
-		return sleet.CVVResponseRequiredButMissing
-	case "D":
-		return sleet.CVVResponseSuspicious
-	default: // Includes "2"
+	sleetCode, ok := cvvMap[rawCvv]
+	if !ok {
 		return sleet.CVVResponseUnknown
 	}
+	return sleetCode
 }
 
 // translateAvs converts a CyberSource AVS response code to its equivalent Sleet standard code.
 func translateAvs(rawAvs string) sleet.AVSResponse {
-	// Codes taken from: https://support.cybersource.com/s/article/AVS-Address-Verification-System-Results
-	switch rawAvs {
-	case "A":
-		return sleet.AVSResponseZipNoMatchAddressMatch
-	case "B":
-		return sleet.AVSResponseNonUsZipUnverifiedAddressMatch
-	case "C":
-		return sleet.AVSResponseNonUsZipNoMatchAddressNoMatch
-	case "D", "M":
-		return sleet.AVSResponseNonUsZipMatchAddressMatch
-	case "E", "G", "S", "U", "1":
-		return sleet.AVSResponseUnsupported
-	case "F", "H":
-		return sleet.AVSResponseNameNoMatch
-	case "I":
-		return sleet.AVSResponseSkipped
-	case "K":
-		return sleet.AVSResponseNameMatchZipNoMatchAddressNoMatch
-	case "L":
-		return sleet.AVSResponseNameMatchZipMatchAddressNoMatch
-	case "N":
-		return sleet.AVSResponseNoMatch
-	case "O":
-		return sleet.AVSResponseNameMatchZipNoMatchAddressMatch
-	case "P":
-		return sleet.AVSResponseZipMatchAddressUnverified
-	case "R":
-		return sleet.AVSResponseError
-	case "T":
-		return sleet.AVSResponseNameNoMatchAddressMatch
-	case "V":
-		return sleet.AVSResponseMatch
-	case "W":
-		return sleet.AVSResponseZip9MatchAddressNoMatch
-	case "X":
-		return sleet.AVSResponseZip9MatchAddressMatch
-	case "Y":
-		return sleet.AVSResponseZip5MatchAddressMatch
-	case "Z":
-		return sleet.AVSResponseZip5MatchAddressNoMatch
-	default: // Includes "2"
+	sleetCode, ok := avsMap[rawAvs]
+	if !ok {
 		return sleet.AVSResponseUnknown
 	}
+	return sleetCode
 }


### PR DESCRIPTION
so it's consistent with other file eg `authorizenet/transaction.go`. Also this helps increasing coverage :P because if we do switch we'd have to test all cases.