### PR TITLE
Adyen - switch logic to only set successful if authorised, else treat…

### DIFF
--- a/gateways/adyen/adyen.go
+++ b/gateways/adyen/adyen.go
@@ -78,12 +78,12 @@ func (client *AdyenClient) Authorize(request *sleet.AuthorizationRequest) (*slee
 		}
 	}
 
-	if result.ResultCode == adyen_common.Refused || result.ResultCode == adyen_common.Error {
+	if result.ResultCode == adyen_common.Authorised {
+		response.Success = true
+	} else {
 		response.Success = false
 		response.ErrorCode = result.RefusalReasonCode
 		response.Response = result.RefusalReason
-	} else {
-		response.Success = true
 	}
 
 	return response, nil

--- a/gateways/adyen/adyen.go
+++ b/gateways/adyen/adyen.go
@@ -78,9 +78,8 @@ func (client *AdyenClient) Authorize(request *sleet.AuthorizationRequest) (*slee
 		}
 	}
 
-	if result.ResultCode == adyen_common.Authorised {
-		response.Success = true
-	} else {
+	response.Success = true
+	if result.ResultCode != adyen_common.Authorised {
 		response.Success = false
 		response.ErrorCode = result.RefusalReasonCode
 		response.Response = result.RefusalReason


### PR DESCRIPTION
… as failed

We found that there is a 3DS response and this logic is kind of backwards, we should only treat as success if we get authorised