### PR TITLE
[authnet] Set Content-Type header in requests

### DIFF
--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -112,13 +112,13 @@ func (client *AuthorizeNetClient) sendRequest(data Request) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	reader := bytes.NewReader(bodyJSON)
 	request, err := http.NewRequest(http.MethodPost, client.url, reader)
 	if err != nil {
 		return nil, err
 	}
 	request.Header.Add("User-Agent", common.UserAgent())
+	request.Header.Add("Content-Type", "application/json")
 
 	resp, err := client.httpClient.Do(request)
 	if err != nil {

--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -112,6 +112,7 @@ func (client *AuthorizeNetClient) sendRequest(data Request) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	reader := bytes.NewReader(bodyJSON)
 	request, err := http.NewRequest(http.MethodPost, client.url, reader)
 	if err != nil {


### PR DESCRIPTION
Because there was no Content-Type header, the bodyParser used in tk was populating `req.body` with an empty object instead of the parsed JSON. Here are two tk traces with the request body logged, the first using sleet as it is and the second using sleet after the change:

1. [Empty object](https://app.datadoghq.com/logs?cols=core_service&event=AQAAAXZoYqkUXqbslQAAAABBWFpvWXJMb0FBRGFDOHR6WHljV1VRQVU&from_ts=1607983870802&index=main&live=true&messageDisplay=inline&query=%40trace_id%3A%22DtT9QjPR0C40ndWNd7JStA%3D%3D%22&stream_sort=desc&to_ts=1608070270802)
2. [Parsed JSON](https://app.datadoghq.com/logs?cols=core_service&event=AQAAAXZoZx21FOor0AAAAABBWFpvWnpDbUFBQl9LVDVBdHowU1BnQVg&from_ts=1607983844001&index=main&live=true&messageDisplay=inline&query=%40trace_id%3A%22IM5ud2tic64l7SWsRew82w%3D%3D%22&stream_sort=desc&to_ts=1608070244001)