### PR TITLE
[authnet] Add Last4 to RefundRequest

### DIFF
--- a/gateways/authorizenet/authorizenet_test.go
+++ b/gateways/authorizenet/authorizenet_test.go
@@ -357,20 +357,6 @@ func TestRefund(t *testing.T) {
 		}
 	})
 
-	t.Run("Request without credit_card results in error", func(t *testing.T) {
-		request := sleet_t.BaseRefundRequest()
-		client := NewClient("MerchantName", "Key", common.Sandbox)
-
-		_, err := client.Refund(request)
-
-		if err == nil {
-			t.Fatalf("Error must be thrown after sending request")
-		}
-		if err.Error() != "missing credit card last four digits" {
-			t.Fatalf("Unexpected error message: %s", err.Error())
-		}
-	})
-
 	t.Run("With Network Error", func(t *testing.T) {
 		request := sleet_t.BaseRefundRequest()
 		httpmock.Activate()

--- a/gateways/authorizenet/authorizenet_test.go
+++ b/gateways/authorizenet/authorizenet_test.go
@@ -144,7 +144,7 @@ func TestAuthorize(t *testing.T) {
 			TransactionReference: "60157186288",
 			AvsResult:            sleet.AVSResponseMatch,
 			CvvResult:            sleet.CVVResponseNotProcessed,
-			ErrorCode: "2",
+			ErrorCode:            "2",
 			AvsResultRaw:         "Y",
 			CvvResultRaw:         "P",
 		}
@@ -303,9 +303,6 @@ func TestRefund(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 
 		request := sleet_t.BaseRefundRequest()
-		request.Options = map[string]interface{}{
-			"credit_card": "1234",
-		}
 		httpmock.RegisterResponder("POST", url, func(req *http.Request) (*http.Response, error) {
 			refundResponseRaw := helper.ReadFile("test_data/refundSuccessResponse.json")
 			resp := httpmock.NewBytesResponse(http.StatusOK, refundResponseRaw)
@@ -335,9 +332,6 @@ func TestRefund(t *testing.T) {
 		defer httpmock.DeactivateAndReset()
 
 		request := sleet_t.BaseRefundRequest()
-		request.Options = map[string]interface{}{
-			"credit_card": "1234",
-		}
 		httpmock.RegisterResponder("POST", url, func(req *http.Request) (*http.Response, error) {
 			refundResponseRaw := helper.ReadFile("test_data/refundErrorResponse.json")
 			resp := httpmock.NewBytesResponse(http.StatusOK, refundResponseRaw)
@@ -345,7 +339,7 @@ func TestRefund(t *testing.T) {
 		})
 
 		want := &sleet.RefundResponse{
-			Success: false,
+			Success:   false,
 			ErrorCode: common.SPtr("16"),
 		}
 
@@ -379,9 +373,6 @@ func TestRefund(t *testing.T) {
 
 	t.Run("With Network Error", func(t *testing.T) {
 		request := sleet_t.BaseRefundRequest()
-		request.Options = map[string]interface{}{
-			"credit_card": "1234",
-		}
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 

--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -1,13 +1,12 @@
 package authorizenet
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/BoltApp/sleet"
 )
 
-func buildAuthRequest(merchantName string, transactionKey string, authRequest *sleet.AuthorizationRequest) *Request{
+func buildAuthRequest(merchantName string, transactionKey string, authRequest *sleet.AuthorizationRequest) *Request {
 	amountStr := sleet.AmountToDecimalString(&authRequest.Amount)
 	billingAddress := authRequest.BillingAddress
 	authorizeRequest := CreateTransactionRequest{
@@ -64,14 +63,6 @@ func buildCaptureRequest(merchantName string, transactionKey string, captureRequ
 }
 
 func buildRefundRequest(merchantName string, transactionKey string, refundRequest *sleet.RefundRequest) (*Request, error) {
-	lastFour, ok := refundRequest.Options["credit_card"]
-	if !ok {
-		return nil, errors.New("missing credit card last four digits")
-	}
-	lastFourAsString := lastFour.(string)
-	if len(lastFourAsString) != 4 {
-		return nil, errors.New("incorrect credit card last four digits")
-	}
 	amountStr := sleet.AmountToDecimalString(refundRequest.Amount)
 	request := &Request{
 		CreateTransactionRequest: CreateTransactionRequest{
@@ -82,7 +73,7 @@ func buildRefundRequest(merchantName string, transactionKey string, refundReques
 				RefTransactionID: &refundRequest.TransactionReference,
 				Payment: &Payment{
 					CreditCard: CreditCard{
-						CardNumber:     lastFourAsString,
+						CardNumber:     refundRequest.Last4,
 						ExpirationDate: expirationDateXXXX,
 					},
 				},

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -133,9 +133,6 @@ func TestBuildRefundRequest(t *testing.T) {
 
 	t.Run("With Valid Requests", func(t *testing.T) {
 		base := sleet_testing.BaseRefundRequest()
-		base.Options = map[string]interface{}{"credit_card": "1111"}
-		// TODO without last four
-		// TODO wrong length last 4
 
 		amount := "1.00"
 
@@ -172,42 +169,6 @@ func TestBuildRefundRequest(t *testing.T) {
 				if err != nil {
 					t.Errorf("ERROR THROWN: Got %q", err)
 				}
-				if diff := deep.Equal(got, c.want); diff != nil {
-					t.Error(diff)
-				}
-			})
-		}
-	})
-
-	t.Run("With invalid requests", func(t *testing.T) {
-		withoutCreditCard := sleet_testing.BaseRefundRequest()
-		withBadCardNumber := sleet_testing.BaseRefundRequest()
-		withBadCardNumber.Options = map[string]interface{}{"credit_card": "4111111111111111"}
-
-		cases := []struct {
-			label string
-			in    *sleet.RefundRequest
-			want  *Request
-		}{
-			{
-				"Without credit card optiont",
-				withoutCreditCard,
-				nil,
-			},
-			{
-				"With bad card number formatting",
-				withBadCardNumber,
-				nil,
-			},
-		}
-
-		for _, c := range cases {
-			t.Run(c.label, func(t *testing.T) {
-				got, err := buildRefundRequest("MerchantName", "Key", c.in)
-				if err == nil {
-					t.Errorf("Error is nil, expected to get error response")
-				}
-
 				if diff := deep.Equal(got, c.want); diff != nil {
 					t.Error(diff)
 				}

--- a/testing/auth_request.go
+++ b/testing/auth_request.go
@@ -35,40 +35,40 @@ func BaseAuthorizationRequest() *sleet.AuthorizationRequest {
 // BaseLevel3Data is used as a testing helper method to standardize request calls for integration tests
 func BaseLevel3Data() *sleet.Level3Data {
 	return &sleet.Level3Data{
-		CustomerReference:      "customer",
-		TaxAmount:              sleet.Amount{
+		CustomerReference: "customer",
+		TaxAmount: sleet.Amount{
 			Amount:   100,
 			Currency: "USD",
 		},
-		DiscountAmount:         sleet.Amount{
+		DiscountAmount: sleet.Amount{
 			Amount:   200,
 			Currency: "USD",
 		},
-		ShippingAmount:         sleet.Amount{
+		ShippingAmount: sleet.Amount{
 			Amount:   300,
 			Currency: "USD",
 		},
-		DutyAmount:             sleet.Amount{
+		DutyAmount: sleet.Amount{
 			Amount:   400,
 			Currency: "USD",
 		},
 		DestinationPostalCode:  "94105",
 		DestinationCountryCode: "US",
-		LineItems:              []sleet.LineItem{
+		LineItems: []sleet.LineItem{
 			{
-				Description:        "pot",
-				ProductCode:        "abc",
-				UnitPrice:          sleet.Amount{
+				Description: "pot",
+				ProductCode: "abc",
+				UnitPrice: sleet.Amount{
 					Amount:   500,
 					Currency: "USD",
 				},
-				Quantity:           2,
-				TotalAmount:        sleet.Amount{
+				Quantity: 2,
+				TotalAmount: sleet.Amount{
 					Amount:   1000,
 					Currency: "USD",
 				},
-				UnitOfMeasure:      "count",
-				CommodityCode:      "cmd",
+				UnitOfMeasure: "count",
+				CommodityCode: "cmd",
 			},
 		},
 	}
@@ -108,6 +108,6 @@ func BaseRefundRequest() *sleet.RefundRequest {
 		Amount:                     &amount,
 		TransactionReference:       "111111",
 		ClientTransactionReference: &clientRef,
-		Options:                    nil,
+		Last4:                      "1111",
 	}
 }

--- a/types.go
+++ b/types.go
@@ -68,7 +68,6 @@ type Level3Data struct {
 
 // AuthorizationRequest specifies needed information for request to authorize by PsPs
 // Note: Only credit cards are supported
-// Note: Options is a generic key-value pair that can be used to provide additional information to PsP
 type AuthorizationRequest struct {
 	Amount                     Amount
 	CreditCard                 *CreditCard

--- a/types.go
+++ b/types.go
@@ -68,6 +68,7 @@ type Level3Data struct {
 
 // AuthorizationRequest specifies needed information for request to authorize by PsPs
 // Note: Only credit cards are supported
+// Note: Options is a generic key-value pair that can be used to provide additional information to PsP
 type AuthorizationRequest struct {
 	Amount                     Amount
 	CreditCard                 *CreditCard
@@ -83,6 +84,7 @@ type AuthorizationRequest struct {
 	// If we are in a recurring situation, then we can use the PreviousExternalTransactionID as part of the auth request
 	ProcessingInitiator           *ProcessingInitiatorType
 	PreviousExternalTransactionID *string
+	Options                       map[string]interface{}
 }
 
 // AuthorizationResponse is a generic response returned back to client after data massaging from PsP Response
@@ -130,12 +132,13 @@ type VoidResponse struct {
 	ErrorCode            *string
 }
 
-// RefundRequest for refunding a captured transaction with amount to be refunded
+// RefundRequest for refunding a captured transaction with generic Options and amount to be refunded
 type RefundRequest struct {
 	Amount                     *Amount
 	TransactionReference       string
 	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
 	Last4                      string
+	Options                    map[string]interface{}
 }
 
 // RefundResponse indicating if request went through successfully

--- a/types.go
+++ b/types.go
@@ -84,7 +84,6 @@ type AuthorizationRequest struct {
 	// If we are in a recurring situation, then we can use the PreviousExternalTransactionID as part of the auth request
 	ProcessingInitiator           *ProcessingInitiatorType
 	PreviousExternalTransactionID *string
-	Options                       map[string]interface{}
 }
 
 // AuthorizationResponse is a generic response returned back to client after data massaging from PsP Response
@@ -132,12 +131,12 @@ type VoidResponse struct {
 	ErrorCode            *string
 }
 
-// RefundRequest for refunding a captured transaction with generic Options and amount to be refunded
+// RefundRequest for refunding a captured transaction with amount to be refunded
 type RefundRequest struct {
 	Amount                     *Amount
 	TransactionReference       string
 	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
-	Options                    map[string]interface{}
+	Last4                      string
 }
 
 // RefundResponse indicating if request went through successfully


### PR DESCRIPTION
Per discussion [here](https://github.com/BoltApp/source/pull/10650#issuecomment-747713085), it no longer makes sense to use the refund request's `Options` field to store the last 4 digits of a credit card only for auth.net. This PR adds a new field to refund request, `Last4`, where we will now store this information.