### PR TITLE
[authnet] return transaction ref for capture, void, and refund

### DIFF
--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -69,7 +69,10 @@ func (client *AuthorizeNetClient) Capture(request *sleet.CaptureRequest) (*sleet
 		errorCode := getErrorCode(authorizeNetResponse.TransactionResponse)
 		return &sleet.CaptureResponse{ErrorCode: &errorCode}, nil
 	}
-	return &sleet.CaptureResponse{Success: true}, nil
+	return &sleet.CaptureResponse{
+		Success:              true,
+		TransactionReference: authorizeNetResponse.TransactionResponse.TransID,
+	}, nil
 }
 
 // Void an existing authorized transaction
@@ -84,7 +87,10 @@ func (client *AuthorizeNetClient) Void(request *sleet.VoidRequest) (*sleet.VoidR
 		errorCode := getErrorCode(authorizeNetResponse.TransactionResponse)
 		return &sleet.VoidResponse{ErrorCode: &errorCode}, nil
 	}
-	return &sleet.VoidResponse{Success: true}, nil
+	return &sleet.VoidResponse{
+		Success:              true,
+		TransactionReference: authorizeNetResponse.TransactionResponse.TransID,
+	}, nil
 }
 
 // Refund a captured transaction with amount and captured transaction reference
@@ -104,7 +110,10 @@ func (client *AuthorizeNetClient) Refund(request *sleet.RefundRequest) (*sleet.R
 		response := sleet.RefundResponse{ErrorCode: &errorCode}
 		return &response, nil
 	}
-	return &sleet.RefundResponse{Success: true}, nil
+	return &sleet.RefundResponse{
+		Success:              true,
+		TransactionReference: authorizeNetResponse.TransactionResponse.TransID,
+	}, nil
 }
 
 func (client *AuthorizeNetClient) sendRequest(data Request) (*Response, error) {

--- a/gateways/authorizenet/authorizenet_test.go
+++ b/gateways/authorizenet/authorizenet_test.go
@@ -313,7 +313,7 @@ func TestRefund(t *testing.T) {
 
 		want := &sleet.RefundResponse{
 			Success:              true,
-			TransactionReference: "1234567890",
+			TransactionReference: "1234569999",
 		}
 
 		client := NewClient("MerchantName", "Key", common.Sandbox)

--- a/gateways/authorizenet/authorizenet_test.go
+++ b/gateways/authorizenet/authorizenet_test.go
@@ -203,7 +203,8 @@ func TestCapture(t *testing.T) {
 		})
 
 		want := &sleet.CaptureResponse{
-			Success: true,
+			Success:              true,
+			TransactionReference: "1234567890",
 		}
 
 		client := NewClient("MerchantName", "Key", common.Sandbox)
@@ -259,7 +260,8 @@ func TestVoid(t *testing.T) {
 		})
 
 		want := &sleet.VoidResponse{
-			Success: true,
+			Success:              true,
+			TransactionReference: "1234567890",
 		}
 
 		client := NewClient("MerchantName", "Key", common.Sandbox)
@@ -310,7 +312,8 @@ func TestRefund(t *testing.T) {
 		})
 
 		want := &sleet.RefundResponse{
-			Success: true,
+			Success:              true,
+			TransactionReference: "1234567890",
 		}
 
 		client := NewClient("MerchantName", "Key", common.Sandbox)


### PR DESCRIPTION
Not returning a transaction ref for captures causes refunds to fail. Found this out while testing https://github.com/BoltApp/source/pull/10650