### PR TITLE
Authorize.net Apple Pay

### DIFF
--- a/common/pointers.go
+++ b/common/pointers.go
@@ -13,3 +13,8 @@ func SafeStr(s *string) string {
 func SPtr(s string) *string {
 	return &s
 }
+
+// BPtr returns a pointer to the bool value b
+func BPtr(b bool) *bool {
+	return &b
+}

--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -2,9 +2,8 @@ package authorizenet
 
 import (
 	"fmt"
-	"github.com/BoltApp/sleet/common"
-
 	"github.com/BoltApp/sleet"
+	"github.com/BoltApp/sleet/common"
 )
 
 func buildAuthRequest(merchantName string, transactionKey string, authRequest *sleet.AuthorizationRequest) *Request {
@@ -17,8 +16,8 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 	}
 	if authRequest.Cryptogram != "" {
 		// Apple Pay request
-		creditCard.Cryptogram = authRequest.Cryptogram
 		creditCard.IsPaymentToken = common.BPtr(true)
+		creditCard.Cryptogram = authRequest.Cryptogram
 	} else {
 		// Credit Card request
 		creditCard.CardCode = authRequest.CreditCard.CVV

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -3,12 +3,11 @@
 package authorizenet
 
 import (
-	"testing"
-
 	"github.com/BoltApp/sleet"
-	"github.com/go-test/deep"
-
+	"github.com/BoltApp/sleet/common"
 	sleet_testing "github.com/BoltApp/sleet/testing"
+	"github.com/go-test/deep"
+	"testing"
 )
 
 func TestBuildAuthRequest(t *testing.T) {

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -3,6 +3,7 @@
 package authorizenet
 
 import (
+	"github.com/BoltApp/sleet/common"
 	"testing"
 
 	"github.com/BoltApp/sleet"
@@ -34,6 +35,42 @@ func TestBuildAuthRequest(t *testing.T) {
 								CardNumber:     "4111111111111111",
 								ExpirationDate: "2023-10",
 								CardCode:       base.CreditCard.CVV,
+							},
+						},
+						BillingAddress: &BillingAddress{
+							FirstName: "Bolt",
+							LastName:  "Checkout",
+							Address:   base.BillingAddress.StreetAddress1,
+							City:      base.BillingAddress.Locality,
+							State:     base.BillingAddress.RegionCode,
+							Zip:       base.BillingAddress.PostalCode,
+							Country:   base.BillingAddress.CountryCode,
+						},
+					},
+				},
+			},
+		},
+		{
+			"Apple Pay Auth Request",
+			&sleet.AuthorizationRequest{
+				Amount:                     base.Amount,
+				CreditCard:                 base.CreditCard,
+				BillingAddress:             base.BillingAddress,
+				ClientTransactionReference: base.ClientTransactionReference,
+				Cryptogram:                 "cryptogram",
+			},
+			&Request{
+				CreateTransactionRequest: CreateTransactionRequest{
+					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
+					TransactionRequest: TransactionRequest{
+						TransactionType: TransactionTypeAuthOnly,
+						Amount:          &amount,
+						Payment: &Payment{
+							CreditCard: CreditCard{
+								CardNumber:     "4111111111111111",
+								ExpirationDate: "2023-10",
+								Cryptogram:     "cryptogram",
+								IsPaymentToken: common.BPtr(true),
 							},
 						},
 						BillingAddress: &BillingAddress{

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -3,7 +3,6 @@
 package authorizenet
 
 import (
-	"github.com/BoltApp/sleet/common"
 	"testing"
 
 	"github.com/BoltApp/sleet"
@@ -69,8 +68,8 @@ func TestBuildAuthRequest(t *testing.T) {
 							CreditCard: CreditCard{
 								CardNumber:     "4111111111111111",
 								ExpirationDate: "2023-10",
-								Cryptogram:     "cryptogram",
 								IsPaymentToken: common.BPtr(true),
+								Cryptogram:     "cryptogram",
 							},
 						},
 						BillingAddress: &BillingAddress{

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -118,6 +118,8 @@ type CreditCard struct {
 	CardNumber     string `json:"cardNumber"`
 	ExpirationDate string `json:"expirationDate"`
 	CardCode       string `json:"cardCode,omitempty"`
+	Cryptogram     string `json:"cryptogram,omitempty"`
+	IsPaymentToken *bool  `json:"isPaymentToken,omitempty"`
 }
 
 // BillingAddress is used in TransactionRequest for making an auth call

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -118,8 +118,8 @@ type CreditCard struct {
 	CardNumber     string `json:"cardNumber"`
 	ExpirationDate string `json:"expirationDate"`
 	CardCode       string `json:"cardCode,omitempty"`
-	Cryptogram     string `json:"cryptogram,omitempty"`
 	IsPaymentToken *bool  `json:"isPaymentToken,omitempty"`
+	Cryptogram     string `json:"cryptogram,omitempty"`
 }
 
 // BillingAddress is used in TransactionRequest for making an auth call


### PR DESCRIPTION
Adding network tokenization fields to the Auth.net CreditCard struct and adding logic to populate those fields when an Apple Pay request is sent through sleet.

[Authorize Net Docs](https://developer.authorize.net/api/reference/index.html#payment-transactions-charge-a-tokenized-credit-card)