### PR TITLE
[auth net] send merchant-defined order reference in auth request

### DIFF
--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -40,10 +40,11 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 				Zip:       billingAddress.PostalCode,
 				Country:   billingAddress.CountryCode,
 			},
-			Order: &Order{
-				InvoiceNumber: authRequest.MerchantOrderReference,
-			},
 		},
+	}
+
+	if authRequest.MerchantOrderReference != "" {
+		authorizeRequest.TransactionRequest.Order = &Order{InvoiceNumber: authRequest.MerchantOrderReference}
 	}
 	return &Request{CreateTransactionRequest: authorizeRequest}
 }

--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -40,6 +40,9 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 				Zip:       billingAddress.PostalCode,
 				Country:   billingAddress.CountryCode,
 			},
+			Order: &Order{
+				InvoiceNumber: authRequest.MerchantOrderReference,
+			},
 		},
 	}
 	return &Request{CreateTransactionRequest: authorizeRequest}

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestBuildAuthRequest(t *testing.T) {
 	base := sleet_testing.BaseAuthorizationRequest()
+	base.MerchantOrderReference = "test_merchant_reference"
 
 	amount := "1.00"
 	cases := []struct {
@@ -43,6 +44,9 @@ func TestBuildAuthRequest(t *testing.T) {
 							State:     base.BillingAddress.RegionCode,
 							Zip:       base.BillingAddress.PostalCode,
 							Country:   base.BillingAddress.CountryCode,
+						},
+						Order: &Order{
+							InvoiceNumber: "test_merchant_reference",
 						},
 					},
 				},

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -105,6 +105,7 @@ type TransactionRequest struct {
 	Payment          *Payment        `json:"payment,omitempty"`
 	BillingAddress   *BillingAddress `json:"billTo,omitempty"`
 	RefTransactionID *string         `json:"refTransId,omitempty"`
+	Order            *Order          `json:"order,omitempty"`
 	// Ignoring Line items, Shipping, Tax, Duty, etc.
 }
 
@@ -132,6 +133,11 @@ type BillingAddress struct {
 	State     *string `json:"state"`
 	Zip       *string `json:"zip"`
 	Country   *string `json:"country"`
+}
+
+// Order is used in TransactionRequest for passing information about the order
+type Order struct {
+	InvoiceNumber string `json:"invoiceNumber"`
 }
 
 // Response is a generic Auth.net response


### PR DESCRIPTION
Passing the merchant order reference as the invoice number lets the merchant see their order number in their auth net dashboard.

Context: https://boltpay.slack.com/archives/C01GKB6D77F/p1622220104001800
Auth net documentation on auth request body: https://developer.authorize.net/api/reference/index.html#payment-transactions