### PR TITLE
[auth net] truncate invoice number to 20 characters

### DIFF
--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -6,6 +6,10 @@ import (
 	"github.com/BoltApp/sleet/common"
 )
 
+const (
+	InvoiceNumberMaxLength = 20
+)
+
 func buildAuthRequest(merchantName string, transactionKey string, authRequest *sleet.AuthorizationRequest) *Request {
 	amountStr := sleet.AmountToDecimalString(&authRequest.Amount)
 	billingAddress := authRequest.BillingAddress
@@ -44,7 +48,8 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 	}
 
 	if authRequest.MerchantOrderReference != "" {
-		authorizeRequest.TransactionRequest.Order = &Order{InvoiceNumber: authRequest.MerchantOrderReference}
+		invoiceNumber := sleet.TruncateString(authRequest.MerchantOrderReference, InvoiceNumberMaxLength)
+		authorizeRequest.TransactionRequest.Order = &Order{InvoiceNumber: invoiceNumber}
 	}
 	return &Request{CreateTransactionRequest: authorizeRequest}
 }

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestBuildAuthRequest(t *testing.T) {
 	base := sleet_testing.BaseAuthorizationRequest()
-	base.MerchantOrderReference = "test_merchant_reference"
+	base.MerchantOrderReference = randomdata.Alphanumeric(24)
 
 	amount := "1.00"
 	cases := []struct {
@@ -46,7 +46,7 @@ func TestBuildAuthRequest(t *testing.T) {
 							Country:   base.BillingAddress.CountryCode,
 						},
 						Order: &Order{
-							InvoiceNumber: "test_merchant_reference",
+							InvoiceNumber: base.MerchantOrderReference[:20],
 						},
 					},
 				},


### PR DESCRIPTION
Per auth.net's documentation, the invoice number can only be 20 characters. Truncating here prevents the request from failing.