### PR TITLE
[nmi] send merchant order reference as order id

### DIFF
--- a/gateways/nmi/nmi.go
+++ b/gateways/nmi/nmi.go
@@ -1,13 +1,14 @@
 package nmi
 
 import (
-	"github.com/BoltApp/sleet"
-	"github.com/BoltApp/sleet/common"
-	"github.com/go-playground/form"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/BoltApp/sleet"
+	"github.com/BoltApp/sleet/common"
+	"github.com/go-playground/form"
 )
 
 const (

--- a/gateways/nmi/request_builders.go
+++ b/gateways/nmi/request_builders.go
@@ -37,6 +37,7 @@ func buildAuthRequest(testMode bool, securityKey string, request *sleet.Authoriz
 		CVV:             &request.CreditCard.CVV,
 		FirstName:       &request.CreditCard.FirstName,
 		LastName:        &request.CreditCard.LastName,
+		OrderID:         request.MerchantOrderReference,
 		SecurityKey:     securityKey,
 		State:           request.BillingAddress.RegionCode,
 		TestMode:        enableTestMode(testMode),

--- a/gateways/nmi/types.go
+++ b/gateways/nmi/types.go
@@ -12,6 +12,7 @@ type Request struct {
 	CVV             *string `form:"cvv,omitempty"`
 	FirstName       *string `form:"first_name,omitempty"`
 	LastName        *string `form:"last_name,omitempty"`
+	OrderID         string  `form:"orderid,omitempty"`
 	SecurityKey     string  `form:"security_key"`
 	State           *string `form:"state,omitempty"`
 	TestMode        *string `form:"test_mode"`
@@ -25,7 +26,7 @@ type Response struct {
 	AuthCode        string `form:"authcode"`
 	AVSResponseCode string `form:"avsresponse"`
 	CVVResponseCode string `form:"cvvresponse"`
-	OrderId         string `form:"orderid"`
+	OrderID         string `form:"orderid"`
 	Response        string `form:"response"`
 	ResponseCode    string `form:"response_code"`
 	ResponseText    string `form:"responsetext"`

--- a/integration-tests/nmi_test.go
+++ b/integration-tests/nmi_test.go
@@ -13,6 +13,7 @@ import (
 func TestNMIAuthorize(t *testing.T) {
 	client := nmi.NewClient(common.Sandbox, getEnv("NMI_SECURITY_KEY"))
 	authRequest := sleet_testing.BaseAuthorizationRequest()
+	authRequest.MerchantOrderReference = "test_merchant_reference"
 
 	rand.Seed(time.Now().UnixNano())
 	minTransaction := 100    // Sending request under $1.00 in test mode causes a decline
@@ -51,6 +52,7 @@ func TestNMIAuthorizeDeclined(t *testing.T) {
 func TestNMIAuthorizeAndCapture(t *testing.T) {
 	client := nmi.NewClient(common.Sandbox, getEnv("NMI_SECURITY_KEY"))
 	authRequest := sleet_testing.BaseAuthorizationRequest()
+	authRequest.MerchantOrderReference = "test_merchant_reference"
 
 	rand.Seed(time.Now().UnixNano())
 	minTransaction := 100    // Sending request under $1.00 in test mode causes a decline


### PR DESCRIPTION
Context: https://app.asana.com/0/1148378495214033/1200449452899513/f