### PR TITLE
Add checks for errorInformation in CyberSource Capture/Refund/Void requests

### DIFF
--- a/gateways/cybersource/cybersource.go
+++ b/gateways/cybersource/cybersource.go
@@ -100,7 +100,7 @@ func (client *CybersourceClient) Capture(request *sleet.CaptureRequest) (*sleet.
 	if err != nil {
 		return nil, err
 	}
-	capturePath := authPath + "/" + request.TransactionReference + "/captures"
+	capturePath := authPath + request.TransactionReference + "/captures"
 	cybersourceResponse, err := client.sendRequest(capturePath, cybersourceCaptureRequest)
 	if err != nil {
 		return nil, err
@@ -121,16 +121,22 @@ func (client *CybersourceClient) Void(request *sleet.VoidRequest) (*sleet.VoidRe
 	if err != nil {
 		return nil, err
 	}
-	voidPath := authPath + "/" + request.TransactionReference + "/voids"
+	voidPath := authPath + request.TransactionReference + "/voids"
 	cybersourceResponse, err := client.sendRequest(voidPath, cybersourceVoidRequest)
 	if err != nil {
 		return nil, err
 	}
-
+	if cybersourceResponse.ErrorInformation != nil {
+		return &sleet.VoidResponse{
+			Success:   false,
+			ErrorCode: &cybersourceResponse.ErrorInformation.Reason,
+		}, nil
+	}
 	if cybersourceResponse.ErrorReason != nil {
-		// return error
-		response := sleet.VoidResponse{ErrorCode: cybersourceResponse.ErrorReason}
-		return &response, nil
+		return &sleet.VoidResponse{
+			Success:   false,
+			ErrorCode: cybersourceResponse.ErrorReason,
+		}, nil
 	}
 	return &sleet.VoidResponse{TransactionReference: *cybersourceResponse.ID, Success: true}, nil
 }
@@ -142,16 +148,22 @@ func (client *CybersourceClient) Refund(request *sleet.RefundRequest) (*sleet.Re
 	if err != nil {
 		return nil, err
 	}
-	refundPath := authPath + "/" + request.TransactionReference + "/refunds"
+	refundPath := authPath + request.TransactionReference + "/refunds"
 	cybersourceResponse, err := client.sendRequest(refundPath, cybersourceRefundRequest)
 	if err != nil {
 		return nil, err
 	}
-
+	if cybersourceResponse.ErrorInformation != nil {
+		return &sleet.RefundResponse{
+			Success:   false,
+			ErrorCode: &cybersourceResponse.ErrorInformation.Reason,
+		}, nil
+	}
 	if cybersourceResponse.ErrorReason != nil {
-		// return error
-		response := sleet.RefundResponse{ErrorCode: cybersourceResponse.ErrorReason, Success: false}
-		return &response, nil
+		return &sleet.RefundResponse{
+			Success:   false,
+			ErrorCode: cybersourceResponse.ErrorReason,
+		}, nil
 	}
 	return &sleet.RefundResponse{Success: true, TransactionReference: *cybersourceResponse.ID}, nil
 }

--- a/gateways/cybersource/cybersource.go
+++ b/gateways/cybersource/cybersource.go
@@ -105,11 +105,17 @@ func (client *CybersourceClient) Capture(request *sleet.CaptureRequest) (*sleet.
 	if err != nil {
 		return nil, err
 	}
-
+	if cybersourceResponse.ErrorInformation != nil {
+		return &sleet.CaptureResponse{
+			Success:   false,
+			ErrorCode: &cybersourceResponse.ErrorInformation.Reason,
+		}, nil
+	}
 	if cybersourceResponse.ErrorReason != nil || cybersourceResponse.ID == nil {
-		// return error
-		response := sleet.CaptureResponse{ErrorCode: cybersourceResponse.ErrorReason}
-		return &response, nil
+		return &sleet.CaptureResponse{
+			Success:   false,
+			ErrorCode: cybersourceResponse.ErrorReason,
+		}, nil
 	}
 	return &sleet.CaptureResponse{Success: true, TransactionReference: *cybersourceResponse.ID}, nil
 }

--- a/gateways/cybersource/cybersource.go
+++ b/gateways/cybersource/cybersource.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -96,6 +97,9 @@ func (client *CybersourceClient) Authorize(request *sleet.AuthorizationRequest) 
 // Multiple captures can be made on the same authorization, but the total amount captured should not exceed the
 // total authorized amount.
 func (client *CybersourceClient) Capture(request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
+	if request.TransactionReference == "" {
+		return nil, errors.New("TransactionReference given to capture request is empty")
+	}
 	cybersourceCaptureRequest, err := buildCaptureRequest(request)
 	if err != nil {
 		return nil, err
@@ -123,6 +127,9 @@ func (client *CybersourceClient) Capture(request *sleet.CaptureRequest) (*sleet.
 // Void cancels a CyberSource payment. If successful, the void response will be returned. A previously voided
 // payment or one that has already been settled cannot be voided.
 func (client *CybersourceClient) Void(request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
+	if request.TransactionReference == "" {
+		return nil, errors.New("TransactionReference given to void request is empty")
+	}
 	cybersourceVoidRequest, err := buildVoidRequest(request)
 	if err != nil {
 		return nil, err
@@ -150,6 +157,9 @@ func (client *CybersourceClient) Void(request *sleet.VoidRequest) (*sleet.VoidRe
 // Refund refunds a CyberSource payment. If successful, the refund response will be returned. Multiple
 // refunds can be made on the same payment, but the total amount refunded should not exceed the payment total.
 func (client *CybersourceClient) Refund(request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
+	if request.TransactionReference == "" {
+		return nil, errors.New("TransactionReference given to refund request is empty")
+	}
 	cybersourceRefundRequest, err := buildRefundRequest(request)
 	if err != nil {
 		return nil, err

--- a/integration-tests/cybersource_test.go
+++ b/integration-tests/cybersource_test.go
@@ -118,17 +118,12 @@ func TestVoid(t *testing.T) {
 func TestMissingReference(t *testing.T) {
 	client := cybersource.NewClient(common.Sandbox, getEnv("CYBERSOURCE_ACCOUNT"), getEnv("CYBERSOURCE_API_KEY"), getEnv("CYBERSOURCE_SHARED_SECRET"))
 	request := sleet_testing.BaseRefundRequest()
-	request.TransactionReference = "" // Cause 404 (request will go to "/pts/v2/payments//refunds")
+	request.TransactionReference = ""
 	resp, err := client.Refund(request)
-	if err != nil {
-		t.Errorf("Expected no error: received: %s", err)
+	if err == nil {
+		t.Error("Expected error, received none")
 	}
-	if resp.Success {
-		t.Errorf("Expected Success: received: %s", *resp.ErrorCode)
-	}
-	if resp.ErrorCode == nil {
-		t.Errorf("Expected error response, got nil")
-	} else if *resp.ErrorCode != "NOT_FOUND" {
-		t.Errorf("Expected error code NOT_FOUND, got %s", *resp.ErrorCode)
+	if resp != nil {
+		t.Errorf("Expected no response, received %v", resp)
 	}
 }

--- a/integration-tests/cybersource_test.go
+++ b/integration-tests/cybersource_test.go
@@ -1,11 +1,12 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/BoltApp/sleet"
 	"github.com/BoltApp/sleet/common"
 	"github.com/BoltApp/sleet/gateways/cybersource"
 	sleet_testing "github.com/BoltApp/sleet/testing"
-	"testing"
 )
 
 func TestAuthorizeAndCaptureAndRefund(t *testing.T) {
@@ -111,5 +112,23 @@ func TestVoid(t *testing.T) {
 	}
 	if voidResp.ErrorCode != nil {
 		t.Errorf("Expected No Error Code: received: %s", *voidResp.ErrorCode)
+	}
+}
+
+func TestMissingReference(t *testing.T) {
+	client := cybersource.NewClient(common.Sandbox, getEnv("CYBERSOURCE_ACCOUNT"), getEnv("CYBERSOURCE_API_KEY"), getEnv("CYBERSOURCE_SHARED_SECRET"))
+	request := sleet_testing.BaseRefundRequest()
+	request.TransactionReference = "" // Cause 404 (request will go to "/pts/v2/payments//refunds")
+	resp, err := client.Refund(request)
+	if err != nil {
+		t.Errorf("Expected no error: received: %s", err)
+	}
+	if resp.Success {
+		t.Errorf("Expected Success: received: %s", *resp.ErrorCode)
+	}
+	if resp.ErrorCode == nil {
+		t.Errorf("Expected error response, got nil")
+	} else if *resp.ErrorCode != "NOT_FOUND" {
+		t.Errorf("Expected error code NOT_FOUND, got %s", *resp.ErrorCode)
 	}
 }


### PR DESCRIPTION
There are two sources of errors in CyberSource API responses: Either as a top level field (as `status` and `reason`) or under `errorInformation` (as `errorInformation.Reason` and `errorInformation.Message`). This adds checks for the second case for Capture, Refund,and Void requests.

Also remove duplicate "/" from request path prefix.

Task: https://app.asana.com/0/1148378495214033/1200494589860753/f