### PR TITLE
[cybs] Add transaction ID to payment auth response body

### DIFF
--- a/gateways/cybersource/types.go
+++ b/gateways/cybersource/types.go
@@ -60,6 +60,7 @@ type ProcessorInformation struct {
 		Code    string `json:"code"`
 		CodeRaw string `json:"codeRaw"`
 	} `json:"avs"`
+	TransactionID string `json:"transactionId"`
 }
 
 // ProcessingInformation specifies various fields for authorize for options (auto-capture, Level3 Data, etc)


### PR DESCRIPTION
We need to capture the transaction ID from cybersource so we can save it in the CC auth table.