### PR TITLE
Add 3DS data to AuthorizationRequest and add to Adyen auths

### DIFF
--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -100,8 +100,8 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 		request.AdditionalData = buildLevel3Data(level3)
 	}
 
-	// Attach results of 3DS verification was performed
-	if authRequest.ThreeDS != nil {
+	// Attach results of 3DS verification if performed (and not "R"ejected)
+	if authRequest.ThreeDS != nil && authRequest.ThreeDS.PAResStatus != "R" {
 		request.MpiData = &checkout.ThreeDSecureData{
 			Cavv:              authRequest.ThreeDS.CAVV,
 			CavvAlgorithm:     authRequest.ThreeDS.CAVVAlgorithm,

--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -100,6 +100,23 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 		request.AdditionalData = buildLevel3Data(level3)
 	}
 
+	// Attach results of 3DS verification was performed
+	if authRequest.ThreeDS != nil {
+		request.MpiData = &checkout.ThreeDSecureData{
+			Cavv:              authRequest.ThreeDS.CAVV,
+			CavvAlgorithm:     authRequest.ThreeDS.CAVVAlgorithm,
+			DirectoryResponse: authRequest.ThreeDS.PAResStatus, // Same as DsTransID for 3DS2
+			DsTransID:         authRequest.ThreeDS.PAResStatus,
+			Eci:               authRequest.ECI,
+			ThreeDSVersion:    authRequest.ThreeDS.Version,
+			Xid:               authRequest.ThreeDS.XID,
+		}
+		// Only pass these fields for challenge flow
+		if !authRequest.ThreeDS.Frictionless {
+			request.MpiData.AuthenticationResponse = authRequest.ThreeDS.PAResStatus
+		}
+	}
+
 	return request
 }
 

--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -101,7 +101,7 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 	}
 
 	// Attach results of 3DS verification if performed (and not "R"ejected)
-	if authRequest.ThreeDS != nil && authRequest.ThreeDS.PAResStatus != "R" {
+	if authRequest.ThreeDS != nil && authRequest.ThreeDS.PAResStatus != sleet.ThreedsStatusRejected {
 		request.MpiData = &checkout.ThreeDSecureData{
 			Cavv:              authRequest.ThreeDS.CAVV,
 			CavvAlgorithm:     authRequest.ThreeDS.CAVVAlgorithm,

--- a/gateways/adyen/request_builder_test.go
+++ b/gateways/adyen/request_builder_test.go
@@ -197,3 +197,30 @@ func TestBuildAuthRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestBuild3DSAuthRequest(t *testing.T) {
+	request := sleet_testing.BaseAuthorizationRequest()
+	result := buildAuthRequest(request, "merchant-account")
+	if result.MpiData != nil {
+		t.Errorf("expected no 3DS fields in request since none were provided but got %v", result.MpiData)
+	}
+
+	request = sleet_testing.BaseAuthorizationRequest()
+	request.ThreeDS = sleet_testing.Base3DS()
+	request.ECI = "eci"
+	result = buildAuthRequest(request, "merchant-account")
+	if result.MpiData == nil {
+		expected := &checkout.ThreeDSecureData{
+			Cavv:              "cavv",
+			CavvAlgorithm:     "cavv-algorithm",
+			DirectoryResponse: "pares-status",
+			DsTransID:         "pares-status",
+			Eci:               "eci",
+			ThreeDSVersion:    "version",
+			Xid:               "xid",
+		}
+		if diff := deep.Equal(result.MpiData, expected); diff != nil {
+			t.Error(diff)
+		}
+	}
+}

--- a/gateways/adyen/request_builder_test.go
+++ b/gateways/adyen/request_builder_test.go
@@ -199,12 +199,20 @@ func TestBuildAuthRequest(t *testing.T) {
 }
 
 func TestBuild3DSAuthRequest(t *testing.T) {
+	// Absent flow
 	request := sleet_testing.BaseAuthorizationRequest()
 	result := buildAuthRequest(request, "merchant-account")
 	if result.MpiData != nil {
 		t.Errorf("expected no 3DS fields in request since none were provided but got %v", result.MpiData)
 	}
 
+	request.ThreeDS.PAResStatus = "R"
+	result := buildAuthRequest(request, "merchant-account")
+	if result.MpiData != nil {
+		t.Errorf("expected no 3DS fields in request due to rejection status but got %v", result.MpiData)
+	}
+
+	// Normal flow
 	request = sleet_testing.BaseAuthorizationRequest()
 	request.ThreeDS = sleet_testing.Base3DS()
 	request.ECI = "eci"

--- a/gateways/cybersource/types.go
+++ b/gateways/cybersource/types.go
@@ -60,6 +60,7 @@ type ProcessorInformation struct {
 		Code    string `json:"code"`
 		CodeRaw string `json:"codeRaw"`
 	} `json:"avs"`
+	TransactionID string `json:"transactionId"`
 }
 
 // ProcessingInformation specifies various fields for authorize for options (auto-capture, Level3 Data, etc)

--- a/testing/auth_request.go
+++ b/testing/auth_request.go
@@ -111,3 +111,19 @@ func BaseRefundRequest() *sleet.RefundRequest {
 		Last4:                      "1111",
 	}
 }
+
+// Base3DS provides a template with 3DS authorization data. Fields are populated by their names
+// since no valid values will exist without first having run 3DS.
+func Base3DS() *sleet.ThreeDS {
+	return &sleet.ThreeDS{
+		Frictionless:     false,
+		ACSTransactionID: "acs-transaction-id",
+		CAVV:             "cavv",
+		CAVVAlgorithm:    "cavv-algorithm",
+		DSTransactionID:  "ds-transaction-id",
+		PAResStatus:      "pares-status",
+		UCAFIndicator:    "ucaf-indicator",
+		Version:          "version",
+		XID:              "xid",
+	}
+}

--- a/threeds.go
+++ b/threeds.go
@@ -1,0 +1,6 @@
+package sleet
+
+// 3DS response codes.
+const (
+	ThreedsStatusRejected = "R"
+)

--- a/types.go
+++ b/types.go
@@ -88,6 +88,7 @@ type AuthorizationRequest struct {
 	PreviousExternalTransactionID *string
 	Options                       map[string]interface{}
 	ShopperReference              string // shopperReference used to get adyen recurring info
+	ThreeDS                       *ThreeDS
 }
 
 // AuthorizationResponse is a generic response returned back to client after data massaging from PsP Response
@@ -176,4 +177,17 @@ type RTAUResponse struct {
 	UpdatedExpiry               *time.Time
 	UpdatedBIN                  string
 	UpdatedLast4                string
+}
+
+// ThreeDS holds results from a 3DS verification challenge.
+type ThreeDS struct {
+	Frictionless     bool   // Whether the 3DS flow for this transaction was frictionless
+	ACSTransactionID string // Transaction ID assigned by ACS
+	CAVV             string // Cardholder Authentication Value
+	CAVVAlgorithm    string // Algorithm used to calculate CAVV
+	DSTransactionID  string // Directory Server (DS) Transaction ID (for 3DS2)
+	PAResStatus      string // Transaction status result
+	UCAFIndicator    string // Universal Cardholder Authentication Field Indicator value provided by issuer
+	Version          string // 3DS Version
+	XID              string // Transaction ID from authentication processing (for 3DS1)
 }


### PR DESCRIPTION
Add field for 3DS verification data to `AuthorizationRequest` and update Adyen request builder to attach this data to auth requests if present.