### PR TITLE
Adding shopperIP, shopperEmail, and ShippingAddress to generic Auth Request + adding support for fields in Ayden

### DIFF
--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -66,18 +66,11 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 		ShopperReference: authRequest.ShopperReference,
 	}
 
-	if authRequest.BillingAddress != nil {
-		request.BillingAddress = &checkout.Address{
-			City:              common.SafeStr(authRequest.BillingAddress.Locality),
-			Country:           common.SafeStr(authRequest.BillingAddress.CountryCode),
-			HouseNumberOrName: common.SafeStr(authRequest.BillingAddress.StreetAddress2),
-			PostalCode:        common.SafeStr(authRequest.BillingAddress.PostalCode),
-			StateOrProvince:   common.SafeStr(authRequest.BillingAddress.RegionCode),
-			Street:            common.SafeStr(authRequest.BillingAddress.StreetAddress1),
-		}
-	}
-
+	addBillingAddress(authRequest, request)
 	addPaymentSpecificFields(authRequest, request)
+	addShopperIP(authRequest, request)
+	addShopperEmail(authRequest, request)
+	addShippingAddress(authRequest, request)
 
 	// overwrites the flag transactions
 	if authRequest.ProcessingInitiator != nil {
@@ -149,6 +142,48 @@ func addPaymentSpecificFields(authRequest *sleet.AuthorizationRequest, request *
 		// Existing customer credit card request
 		request.RecurringProcessingModel = "CardOnFile"
 		request.ShopperInteraction = "ContAuth"
+	}
+}
+
+// addBillingAddress adds the billing address to the Ayden Payment request if available
+func addBillingAddress(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
+	if authRequest.BillingAddress != nil {
+		request.BillingAddress = &checkout.Address{
+			City:              common.SafeStr(authRequest.BillingAddress.Locality),
+			Country:           common.SafeStr(authRequest.BillingAddress.CountryCode),
+			HouseNumberOrName: common.SafeStr(authRequest.BillingAddress.StreetAddress2),
+			PostalCode:        common.SafeStr(authRequest.BillingAddress.PostalCode),
+			StateOrProvince:   common.SafeStr(authRequest.BillingAddress.RegionCode),
+			Street:            common.SafeStr(authRequest.BillingAddress.StreetAddress1),
+		}
+	}
+}
+
+// addShopperIP adds the shoppers IP to the Ayden Payment request if available
+func addShopperIP(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
+	if authRequest.ShopperIP != nil {
+		request.ShopperIP = common.SafeStr(authRequest.ShopperIP)
+	}
+}
+
+// addShopperEmail adds the shoppers email to the Ayden Payment request if available
+func addShopperEmail(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
+	if authRequest.ShopperEmail != nil {
+		request.ShopperEmail = common.SafeStr(authRequest.ShopperEmail)
+	}
+}
+
+// addShippingAddress adds the shipping address to the Ayden Payment request if available
+func addShippingAddress(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
+	if authRequest.ShippingAddress != nil {
+		request.DeliveryAddress = &checkout.Address{
+			City:              common.SafeStr(authRequest.ShippingAddress.Locality),
+			Country:           common.SafeStr(authRequest.ShippingAddress.CountryCode),
+			HouseNumberOrName: common.SafeStr(authRequest.ShippingAddress.StreetAddress2),
+			PostalCode:        common.SafeStr(authRequest.ShippingAddress.PostalCode),
+			StateOrProvince:   common.SafeStr(authRequest.ShippingAddress.RegionCode),
+			Street:            common.SafeStr(authRequest.ShippingAddress.StreetAddress1),
+		}
 	}
 }
 

--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -172,8 +172,8 @@ func addShopperData(authRequest *sleet.AuthorizationRequest, request *checkout.P
 	if authRequest.Options["ShopperIP"] != nil {
 		request.ShopperIP = authRequest.Options["ShopperIP"].(string)
 	}
-	if authRequest.ShopperEmail != nil {
-		request.ShopperEmail = common.SafeStr(authRequest.ShopperEmail)
+	if authRequest.BillingAddress.Email != nil {
+		request.ShopperEmail = common.SafeStr(authRequest.BillingAddress.Email)
 	}
 }
 

--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -66,11 +66,9 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 		ShopperReference: authRequest.ShopperReference,
 	}
 
-	addBillingAddress(authRequest, request)
 	addPaymentSpecificFields(authRequest, request)
-	addShopperIP(authRequest, request)
-	addShopperEmail(authRequest, request)
-	addShippingAddress(authRequest, request)
+	addShopperData(authRequest, request)
+	addAddresses(authRequest, request)
 
 	// overwrites the flag transactions
 	if authRequest.ProcessingInitiator != nil {
@@ -145,8 +143,8 @@ func addPaymentSpecificFields(authRequest *sleet.AuthorizationRequest, request *
 	}
 }
 
-// addBillingAddress adds the billing address to the Ayden Payment request if available
-func addBillingAddress(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
+// addAddresses adds the billing address and shipping address to the Ayden Payment request if available
+func addAddresses(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
 	if authRequest.BillingAddress != nil {
 		request.BillingAddress = &checkout.Address{
 			City:              common.SafeStr(authRequest.BillingAddress.Locality),
@@ -157,24 +155,6 @@ func addBillingAddress(authRequest *sleet.AuthorizationRequest, request *checkou
 			Street:            common.SafeStr(authRequest.BillingAddress.StreetAddress1),
 		}
 	}
-}
-
-// addShopperIP adds the shoppers IP to the Ayden Payment request if available
-func addShopperIP(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
-	if authRequest.ShopperIP != nil {
-		request.ShopperIP = common.SafeStr(authRequest.ShopperIP)
-	}
-}
-
-// addShopperEmail adds the shoppers email to the Ayden Payment request if available
-func addShopperEmail(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
-	if authRequest.ShopperEmail != nil {
-		request.ShopperEmail = common.SafeStr(authRequest.ShopperEmail)
-	}
-}
-
-// addShippingAddress adds the shipping address to the Ayden Payment request if available
-func addShippingAddress(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
 	if authRequest.ShippingAddress != nil {
 		request.DeliveryAddress = &checkout.Address{
 			City:              common.SafeStr(authRequest.ShippingAddress.Locality),
@@ -184,6 +164,16 @@ func addShippingAddress(authRequest *sleet.AuthorizationRequest, request *checko
 			StateOrProvince:   common.SafeStr(authRequest.ShippingAddress.RegionCode),
 			Street:            common.SafeStr(authRequest.ShippingAddress.StreetAddress1),
 		}
+	}
+}
+
+// addShopperData adds the shoppers IP and email to the Ayden Payment request if available
+func addShopperData(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
+	if authRequest.ShopperIP != nil {
+		request.ShopperIP = common.SafeStr(authRequest.ShopperIP)
+	}
+	if authRequest.ShopperEmail != nil {
+		request.ShopperEmail = common.SafeStr(authRequest.ShopperEmail)
 	}
 }
 

--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -169,8 +169,8 @@ func addAddresses(authRequest *sleet.AuthorizationRequest, request *checkout.Pay
 
 // addShopperData adds the shoppers IP and email to the Ayden Payment request if available
 func addShopperData(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
-	if authRequest.ShopperIP != nil {
-		request.ShopperIP = common.SafeStr(authRequest.ShopperIP)
+	if authRequest.Options["ShopperIP"] != nil {
+		request.ShopperIP = authRequest.Options["ShopperIP"].(string)
 	}
 	if authRequest.ShopperEmail != nil {
 		request.ShopperEmail = common.SafeStr(authRequest.ShopperEmail)

--- a/gateways/adyen/request_builder_test.go
+++ b/gateways/adyen/request_builder_test.go
@@ -103,7 +103,7 @@ func TestBuildAuthRequest(t *testing.T) {
 					StateOrProvince: *baseWithAydenData.ShippingAddress.RegionCode,
 					Street:          *baseWithAydenData.ShippingAddress.StreetAddress1,
 				},
-				ShopperEmail: *baseWithAydenData.ShopperEmail,
+				ShopperEmail: *baseWithAydenData.BillingAddress.Email,
 				ShopperIP:    "192.168.0.0",
 			},
 		},

--- a/gateways/adyen/request_builder_test.go
+++ b/gateways/adyen/request_builder_test.go
@@ -104,7 +104,7 @@ func TestBuildAuthRequest(t *testing.T) {
 					Street:          *baseWithAydenData.ShippingAddress.StreetAddress1,
 				},
 				ShopperEmail: *baseWithAydenData.ShopperEmail,
-				ShopperIP:    *baseWithAydenData.ShopperIP,
+				ShopperIP:    "192.168.0.0",
 			},
 		},
 		{
@@ -282,7 +282,10 @@ func TestBuild3DSAuthRequest(t *testing.T) {
 }
 
 func enhanceBaseAuthorizationDataWithAdditionalFields(authRequest *sleet.AuthorizationRequest) {
-	authRequest.ShopperIP = common.SPtr("192.168.0.0")
+	if authRequest.Options == nil {
+		authRequest.Options = make(map[string]interface{})
+	}
+	authRequest.Options["ShopperIP"] = "192.168.0.0"
 	authRequest.ShopperEmail = common.SPtr("test@bolt.com")
 	authRequest.ShippingAddress = &sleet.Address{
 		PostalCode:     common.SPtr("94103"),

--- a/gateways/adyen/request_builder_test.go
+++ b/gateways/adyen/request_builder_test.go
@@ -286,7 +286,7 @@ func enhanceBaseAuthorizationDataWithAdditionalFields(authRequest *sleet.Authori
 		authRequest.Options = make(map[string]interface{})
 	}
 	authRequest.Options["ShopperIP"] = "192.168.0.0"
-	authRequest.ShopperEmail = common.SPtr("test@bolt.com")
+	authRequest.BillingAddress.Email = common.SPtr("test@bolt.com")
 	authRequest.ShippingAddress = &sleet.Address{
 		PostalCode:     common.SPtr("94103"),
 		CountryCode:    common.SPtr("US"),

--- a/integration-tests/adyen_test.go
+++ b/integration-tests/adyen_test.go
@@ -177,6 +177,24 @@ func TestAdyenAuth(t *testing.T) {
 	}
 }
 
+// TestAdyenAuthWithIPEmailShippingAddress
+//
+// This should successfully create an authorization on Adyen for a new customer with IP, email, and shipping address
+// included
+func TestAdyenAuthWithIPEmailShippingAddress(t *testing.T) {
+	client := adyen.NewClient(getEnv("ADYEN_ACCOUNT"), getEnv("ADYEN_KEY"), "", common.Sandbox)
+	request := adyenBaseAuthRequest()
+	adyenEnhanceAuthRequestIPEmailShipping(request)
+	auth, err := client.Authorize(request)
+	if err != nil {
+		t.Error("Authorize request should not have failed")
+	}
+
+	if !auth.Success {
+		t.Error("Resulting auth should have been successful")
+	}
+}
+
 // TestAdyenRechargeAuth
 //
 // This should successfully create an authorization on Adyen for an existing customer
@@ -348,4 +366,10 @@ func adyenBaseAuthRequest() *sleet.AuthorizationRequest {
 	request.CreditCard.ExpirationMonth = 3
 	request.CreditCard.ExpirationYear = 2030
 	return request
+}
+
+func adyenEnhanceAuthRequestIPEmailShipping(request *sleet.AuthorizationRequest) {
+	request.ShopperEmail = sPtr("test@bolt.com")
+	request.ShopperIP = sPtr("192.168.0.0")
+	request.ShippingAddress = request.BillingAddress
 }

--- a/integration-tests/adyen_test.go
+++ b/integration-tests/adyen_test.go
@@ -370,6 +370,10 @@ func adyenBaseAuthRequest() *sleet.AuthorizationRequest {
 
 func adyenEnhanceAuthRequestIPEmailShipping(request *sleet.AuthorizationRequest) {
 	request.ShopperEmail = sPtr("test@bolt.com")
-	request.ShopperIP = sPtr("192.168.0.0")
 	request.ShippingAddress = request.BillingAddress
+
+	if request.Options == nil {
+		request.Options = make(map[string]interface{})
+	}
+	request.Options["ShopperIP"] = "192.168.0.0"
 }

--- a/integration-tests/adyen_test.go
+++ b/integration-tests/adyen_test.go
@@ -369,7 +369,7 @@ func adyenBaseAuthRequest() *sleet.AuthorizationRequest {
 }
 
 func adyenEnhanceAuthRequestIPEmailShipping(request *sleet.AuthorizationRequest) {
-	request.ShopperEmail = sPtr("test@bolt.com")
+	request.BillingAddress.Email = sPtr("test@bolt.com")
 	request.ShippingAddress = request.BillingAddress
 
 	if request.Options == nil {

--- a/integration-tests/adyen_test.go
+++ b/integration-tests/adyen_test.go
@@ -60,7 +60,7 @@ func TestAdyenAuthFailedAVSPresent(t *testing.T) {
 	client := adyen.NewClient(getEnv("ADYEN_ACCOUNT"), getEnv("ADYEN_KEY"), "", common.Sandbox)
 	expiredRequest := adyenBaseAuthRequest()
 	expiredRequest.CreditCard.ExpirationYear = 2010
-	expiredRequest.BillingAddress = &sleet.BillingAddress{
+	expiredRequest.BillingAddress = &sleet.Address{
 		StreetAddress1: common.SPtr("1600 Pennsylvania Ave NE"),
 		Locality:       common.SPtr("Washington"),
 		CountryCode:    common.SPtr("US"),
@@ -102,7 +102,7 @@ func TestAdyenAVSCode1(t *testing.T) {
 	client := adyen.NewClient(getEnv("ADYEN_ACCOUNT"), getEnv("ADYEN_KEY"), "", common.Sandbox)
 	avsRequest := adyenBaseAuthRequest()
 	avsRequest.CreditCard.Number = "5500000000000004"
-	avsRequest.BillingAddress = &sleet.BillingAddress{
+	avsRequest.BillingAddress = &sleet.Address{
 		StreetAddress1: common.SPtr("1600 Pennsylvania Ave NE"),
 		Locality:       common.SPtr("Washington"),
 		CountryCode:    common.SPtr("US"),
@@ -136,7 +136,7 @@ func TestAdyenAVSCode2(t *testing.T) {
 	client := adyen.NewClient(getEnv("ADYEN_ACCOUNT"), getEnv("ADYEN_KEY"), "", common.Sandbox)
 	avsRequest := adyenBaseAuthRequest()
 	avsRequest.CreditCard.Number = "5500000000000004"
-	avsRequest.BillingAddress = &sleet.BillingAddress{
+	avsRequest.BillingAddress = &sleet.Address{
 		StreetAddress1: common.SPtr("1599 Pennsylvania Ave NE"),
 		Locality:       common.SPtr("Washington"),
 		CountryCode:    common.SPtr("US"),

--- a/integration-tests/cybersource_test.go
+++ b/integration-tests/cybersource_test.go
@@ -14,7 +14,7 @@ func TestAuthorizeAndCaptureAndRefund(t *testing.T) {
 	client := cybersource.NewClient(common.Sandbox, getEnv("CYBERSOURCE_ACCOUNT"), getEnv("CYBERSOURCE_API_KEY"), getEnv("CYBERSOURCE_SHARED_SECRET"))
 	authRequest := sleet_testing.BaseAuthorizationRequest()
 	authRequest.ClientTransactionReference = sPtr("[auth]-CUSTOMER-REFERENCE-CODE") // This will be overridden by the level 3 CustomerReference
-	authRequest.BillingAddress = &sleet.BillingAddress{
+	authRequest.BillingAddress = &sleet.Address{
 		StreetAddress1: sPtr("77 Geary St"),
 		StreetAddress2: sPtr("Floor 4"),
 		Locality:       sPtr("San Francisco"),
@@ -84,7 +84,7 @@ func TestVoid(t *testing.T) {
 	client := cybersource.NewClient(common.Sandbox, getEnv("CYBERSOURCE_ACCOUNT"), getEnv("CYBERSOURCE_API_KEY"), getEnv("CYBERSOURCE_SHARED_SECRET"))
 	authRequest := sleet_testing.BaseAuthorizationRequest()
 	authRequest.ClientTransactionReference = sPtr("[auth]-CUSTOMER-REFERENCE-CODE")
-	authRequest.BillingAddress = &sleet.BillingAddress{
+	authRequest.BillingAddress = &sleet.Address{
 		StreetAddress1: sPtr("77 Geary St"),
 		StreetAddress2: sPtr("Floor 4"),
 		Locality:       sPtr("San Francisco"),

--- a/testing/auth_request.go
+++ b/testing/auth_request.go
@@ -12,7 +12,7 @@ func BaseAuthorizationRequest() *sleet.AuthorizationRequest {
 		Amount:   100,
 		Currency: "USD",
 	}
-	address := sleet.BillingAddress{
+	address := sleet.Address{
 		PostalCode:     common.SPtr("94103"),
 		CountryCode:    common.SPtr("US"),
 		StreetAddress1: common.SPtr("7683 Railroad Street"),

--- a/types.go
+++ b/types.go
@@ -83,7 +83,6 @@ type AuthorizationRequest struct {
 	ECI                        string  // E-Commerce Indicator (can be used for Network Tokenization as well)
 	MerchantOrderReference     string  // Similar to ClientTransactionReference but specifically if we want to store the shopping cart order id
 	ShippingAddress            *Address
-	ShopperIP                  *string
 	ShopperEmail               *string
 
 	// For Card on File transactions we want to store the various different types (initial cof, initial recurring, etc)

--- a/types.go
+++ b/types.go
@@ -18,8 +18,9 @@ type Amount struct {
 	Currency string
 }
 
-// BillingAddress used for AVS checks for auth calls
-type BillingAddress struct {
+// Address generic address to represent billing address, shipping address, etc.
+// used for AVS checks for auth calls
+type Address struct {
 	StreetAddress1 *string
 	StreetAddress2 *string
 	Locality       *string
@@ -74,13 +75,16 @@ type Level3Data struct {
 type AuthorizationRequest struct {
 	Amount                     Amount
 	CreditCard                 *CreditCard
-	BillingAddress             *BillingAddress
+	BillingAddress             *Address
 	Level3Data                 *Level3Data
 	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
 	Channel                    string  // for Psps that track the sales channel
 	Cryptogram                 string  // for Network Tokenization methods
 	ECI                        string  // E-Commerce Indicator (can be used for Network Tokenization as well)
 	MerchantOrderReference     string  // Similar to ClientTransactionReference but specifically if we want to store the shopping cart order id
+	ShippingAddress            *Address
+	ShopperIP                  *string
+	ShopperEmail               *string
 
 	// For Card on File transactions we want to store the various different types (initial cof, initial recurring, etc)
 	// If we are in a recurring situation, then we can use the PreviousExternalTransactionID as part of the auth request

--- a/types.go
+++ b/types.go
@@ -73,25 +73,22 @@ type Level3Data struct {
 // Note: Only credit cards are supported
 // Note: Options is a generic key-value pair that can be used to provide additional information to PsP
 type AuthorizationRequest struct {
-	Amount                     Amount
-	CreditCard                 *CreditCard
-	BillingAddress             *Address
-	Level3Data                 *Level3Data
-	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
-	Channel                    string  // for Psps that track the sales channel
-	Cryptogram                 string  // for Network Tokenization methods
-	ECI                        string  // E-Commerce Indicator (can be used for Network Tokenization as well)
-	MerchantOrderReference     string  // Similar to ClientTransactionReference but specifically if we want to store the shopping cart order id
-	ShippingAddress            *Address
-	ShopperEmail               *string
-
-	// For Card on File transactions we want to store the various different types (initial cof, initial recurring, etc)
-	// If we are in a recurring situation, then we can use the PreviousExternalTransactionID as part of the auth request
-	ProcessingInitiator           *ProcessingInitiatorType
-	PreviousExternalTransactionID *string
-	Options                       map[string]interface{}
+	Amount                        Amount
+	BillingAddress                *Address
+	Channel                       string  // for Psps that track the sales channel
+	ClientTransactionReference    *string // Custom transaction reference metadata that will be associated with this request
+	CreditCard                    *CreditCard
+	Cryptogram                    string // for Network Tokenization methods
+	ECI                           string // E-Commerce Indicator (can be used for Network Tokenization as well)
+	Level3Data                    *Level3Data
+	MerchantOrderReference        string                   // Similar to ClientTransactionReference but specifically if we want to store the shopping cart order id
+	PreviousExternalTransactionID *string                  // If we are in a recurring situation, then we can use the PreviousExternalTransactionID as part of the auth request
+	ProcessingInitiator           *ProcessingInitiatorType // For Card on File transactions we want to store the various different types (initial cof, initial recurring, etc)
+	ShippingAddress               *Address
 	ShopperReference              string // shopperReference used to get adyen recurring info
 	ThreeDS                       *ThreeDS
+
+	Options map[string]interface{}
 }
 
 // AuthorizationResponse is a generic response returned back to client after data massaging from PsP Response


### PR DESCRIPTION
Adding ShippingAddress to Auth request
Refactoring BillingAddress type to reflect it being generic Address
Supporting new fields for Ayden request (ShopperIP, ShopperEmail, ShippingAddress)