### PR TITLE
Use DSTransID insteadof PAResStatus for Adyen MpiData

### DIFF
--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -99,8 +99,8 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 		request.MpiData = &checkout.ThreeDSecureData{
 			Cavv:              authRequest.ThreeDS.CAVV,
 			CavvAlgorithm:     authRequest.ThreeDS.CAVVAlgorithm,
-			DirectoryResponse: authRequest.ThreeDS.PAResStatus, // Same as DsTransID for 3DS2
-			DsTransID:         authRequest.ThreeDS.PAResStatus,
+			DirectoryResponse: authRequest.ThreeDS.PAResStatus,
+			DsTransID:         authRequest.ThreeDS.DSTransactionID,
 			Eci:               authRequest.ECI,
 			ThreeDSVersion:    authRequest.ThreeDS.Version,
 			Xid:               authRequest.ThreeDS.XID,

--- a/gateways/adyen/request_builder_test.go
+++ b/gateways/adyen/request_builder_test.go
@@ -276,7 +276,7 @@ func TestBuild3DSAuthRequest(t *testing.T) {
 			Cavv:              "cavv",
 			CavvAlgorithm:     "cavv-algorithm",
 			DirectoryResponse: "pares-status",
-			DsTransID:         "pares-status",
+			DsTransID:         "ds-trans-id",
 			Eci:               "eci",
 			ThreeDSVersion:    "version",
 			Xid:               "xid",


### PR DESCRIPTION
Based on Cardinal's feedback the Mastercard failures may be either due to the 3DS version or the Directory Server Transaction ID. This PR updates to use the stored ID instead of the status.

#mergeWhenGreen