### PR TITLE
Replace ClientRef Code with MerchantOrderRef

### DIFF
--- a/gateways/cybersource/request_builders.go
+++ b/gateways/cybersource/request_builders.go
@@ -49,6 +49,7 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest) (*Request, error)
 	amountStr := sleet.AmountToDecimalString(&authRequest.Amount)
 	request := &Request{
 		ClientReferenceInformation: &ClientReferenceInformation{
+			Code: authRequest.MerchantOrderReference,
 			Partner: Partner{
 				SolutionID: authRequest.Channel,
 			},
@@ -93,7 +94,10 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest) (*Request, error)
 	}
 	// If level 3 data is present, and ClientReferenceInformation in that data exists, it will override this.
 	if authRequest.ClientTransactionReference != nil {
-		request.ClientReferenceInformation.Code = *authRequest.ClientTransactionReference
+		request.MerchantDefinedInformation = append(request.MerchantDefinedInformation, MerchantDefinedInformation{
+			Key: "1",
+			Value: *authRequest.ClientTransactionReference,
+		})
 	}
 	if authRequest.Level3Data != nil {
 		level3 := authRequest.Level3Data

--- a/gateways/cybersource/types.go
+++ b/gateways/cybersource/types.go
@@ -2,10 +2,11 @@ package cybersource
 
 // Request contains the information needed for all request types (Auth, Capture, Void, Refund)
 type Request struct {
-	ClientReferenceInformation *ClientReferenceInformation `json:"clientReferenceInformation,omitempty"`
-	ProcessingInformation      *ProcessingInformation      `json:"processingInformation,omitempty"`
-	OrderInformation           *OrderInformation           `json:"orderInformation,omitempty"`
-	PaymentInformation         *PaymentInformation         `json:"paymentInformation,omitempty"`
+	ClientReferenceInformation *ClientReferenceInformation   `json:"clientReferenceInformation,omitempty"`
+	ProcessingInformation      *ProcessingInformation        `json:"processingInformation,omitempty"`
+	OrderInformation           *OrderInformation             `json:"orderInformation,omitempty"`
+	PaymentInformation         *PaymentInformation           `json:"paymentInformation,omitempty"`
+	MerchantDefinedInformation []MerchantDefinedInformation  `json:"merchantDefinedInformation,omitempty"`
 }
 
 // Response contains all of the fields for all Cybersource API call responses
@@ -138,6 +139,12 @@ type ShippingDetails struct {
 // PaymentInformation just stores Card information (but can be extended to other payment types)
 type PaymentInformation struct {
 	Card CardInformation `json:"card"`
+}
+
+// MerchantDefinedInformation stores the custom data that the merchant defines.
+type MerchantDefinedInformation struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // CardInformation stores raw credit card details


### PR DESCRIPTION
Replace ClientReferenceInformation.Code with MerchantOrderReference (DisplayID) which used ClientTransactionReference (Bolt Order Reference) before. 

And add MerchantDefinedInformation to add ClientTransactionReference (Bolt Order Reference) there as custom merchant info.


Test:

<img width="1792" alt="Screen Shot 2021-11-02 at 5 10 12 PM" src="https://user-images.githubusercontent.com/13541433/139968495-7e99a15d-51f9-4462-aa24-73856970cd66.png">
<img width="1792" alt="Screen Shot 2021-11-02 at 5 10 38 PM" src="https://user-images.githubusercontent.com/13541433/139968501-7831a3cb-cbdb-46ee-b420-49ee81f81a1b.png">
