### PR TITLE
Add MerchantOrderReference to Cybersource

### DIFF
--- a/gateways/cybersource/request_builder_test.go
+++ b/gateways/cybersource/request_builder_test.go
@@ -1,0 +1,211 @@
+// +build unit
+
+package cybersource
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/BoltApp/sleet"
+	"github.com/BoltApp/sleet/common"
+	"github.com/go-test/deep"
+
+	sleet_testing "github.com/BoltApp/sleet/testing"
+)
+
+func TestBuildAuthRequest(t *testing.T) {
+	base := sleet_testing.BaseAuthorizationRequest()
+	base.Channel = "channel"
+	base.MerchantOrderReference = "cart_display_id"
+
+	cases := []struct {
+		label string
+		in    *sleet.AuthorizationRequest
+		want  *Request
+	}{
+		{
+			"Basic Auth Request",
+			base,
+			&Request{
+				ClientReferenceInformation: &ClientReferenceInformation{
+					Code: base.MerchantOrderReference,
+					Partner: Partner{
+						SolutionID: base.Channel,
+					},
+				},
+				ProcessingInformation: &ProcessingInformation{
+					Capture:           false, // no autocapture for now
+					CommerceIndicator: "internet",
+					AuthorizationOptions: &AuthorizationOptions{
+						Initiator: &Initiator{
+							InitiatorType: "",
+							CredentialStoredOnFile: false,
+							StoredCredentialUsed: false,
+						},
+					},
+				},
+				PaymentInformation: &PaymentInformation{
+					Card: CardInformation{
+						ExpYear:  strconv.Itoa(base.CreditCard.ExpirationYear),
+						ExpMonth: strconv.Itoa(base.CreditCard.ExpirationMonth),
+						Number:   base.CreditCard.Number,
+						CVV:      base.CreditCard.CVV,
+					},
+				},
+				OrderInformation: &OrderInformation{
+					AmountDetails: AmountDetails{
+						Amount:   "1.00",
+						Currency: "USD",
+					},
+					BillTo: BillingInformation{
+						FirstName:  base.CreditCard.FirstName,
+						LastName:   base.CreditCard.LastName,
+						Address1:   *base.BillingAddress.StreetAddress1,
+						Address2:   common.SafeStr(base.BillingAddress.StreetAddress2),
+						PostalCode: *base.BillingAddress.PostalCode,
+						Locality:   *base.BillingAddress.Locality,
+						AdminArea:  *base.BillingAddress.RegionCode,
+						Country:    common.SafeStr(base.BillingAddress.CountryCode),
+						Email:      common.SafeStr(base.BillingAddress.Email),
+						Company:    common.SafeStr(base.BillingAddress.Company),
+					},
+				},
+				MerchantDefinedInformation: []MerchantDefinedInformation{
+					{
+						Key:   "1",
+						Value: *base.ClientTransactionReference,
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			got, _ := buildAuthRequest(c.in)
+			if diff := deep.Equal(got, c.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestBuildCaptureRequest(t *testing.T) {
+	base := sleet_testing.BaseCaptureRequest()
+	base.MerchantOrderReference = common.SPtr("cart_display_id")
+
+	cases := []struct {
+		label string
+		in    *sleet.CaptureRequest
+		want  *Request
+	}{
+		{
+			"Basic Capture Request",
+			base,
+			&Request {
+				OrderInformation: &OrderInformation{
+					AmountDetails: AmountDetails{
+						Amount:   "1.00",
+						Currency: "USD",
+					},
+				},
+				ClientReferenceInformation: &ClientReferenceInformation{
+					Code: *base.MerchantOrderReference,
+				},
+				MerchantDefinedInformation: []MerchantDefinedInformation{
+					{
+						Key:   "1",
+						Value: *base.ClientTransactionReference,
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			got, _ := buildCaptureRequest(c.in)
+			if diff := deep.Equal(got, c.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestBuildVoidRequest(t *testing.T) {
+	base := sleet_testing.BaseVoidRequest()
+	base.MerchantOrderReference = common.SPtr("cart_display_id")
+
+	cases := []struct {
+		label string
+		in    *sleet.VoidRequest
+		want  *Request
+	}{
+		{
+			"Basic Void Request",
+			base,
+			&Request{
+				ClientReferenceInformation: &ClientReferenceInformation{
+					Code: *base.MerchantOrderReference,
+				},
+				MerchantDefinedInformation: []MerchantDefinedInformation{
+					{
+						Key:   "1",
+						Value: *base.ClientTransactionReference,
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			got, _ := buildVoidRequest(c.in)
+			if diff := deep.Equal(got, c.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestBuildRefundRequest(t *testing.T) {
+	base := sleet_testing.BaseRefundRequest()
+	base.MerchantOrderReference = common.SPtr("cart_display_id")
+
+	cases := []struct {
+		label string
+		in    *sleet.RefundRequest
+		want  *Request
+	}{
+		{
+			"Basic Refund Request",
+			base,
+			&Request{
+				OrderInformation: &OrderInformation{
+					AmountDetails: AmountDetails{
+						Amount:   "1.00",
+						Currency: "USD",
+					},
+				},
+				ClientReferenceInformation: &ClientReferenceInformation{
+					Code: *base.MerchantOrderReference,
+				},
+				MerchantDefinedInformation: []MerchantDefinedInformation{
+					{
+						Key:   "1",
+						Value: *base.ClientTransactionReference,
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			got, _ := buildRefundRequest(c.in)
+			if diff := deep.Equal(got, c.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/gateways/cybersource/request_builders.go
+++ b/gateways/cybersource/request_builders.go
@@ -143,10 +143,16 @@ func buildCaptureRequest(captureRequest *sleet.CaptureRequest) (*Request, error)
 			},
 		},
 	}
-	if captureRequest.ClientTransactionReference != nil {
+	if captureRequest.MerchantOrderReference != nil {
 		request.ClientReferenceInformation = &ClientReferenceInformation{
-			Code: *captureRequest.ClientTransactionReference,
+			Code: *captureRequest.MerchantOrderReference,
 		}
+	}
+	if captureRequest.ClientTransactionReference != nil {
+		request.MerchantDefinedInformation = append(request.MerchantDefinedInformation, MerchantDefinedInformation{
+			Key: "1",
+			Value: *captureRequest.ClientTransactionReference,
+		})
 	}
 	return request, nil
 }
@@ -154,10 +160,16 @@ func buildCaptureRequest(captureRequest *sleet.CaptureRequest) (*Request, error)
 func buildVoidRequest(voidRequest *sleet.VoidRequest) (*Request, error) {
 	// Maybe add reason / more details, but for now nothing
 	request := &Request{}
-	if voidRequest.ClientTransactionReference != nil {
+	if voidRequest.MerchantOrderReference != nil {
 		request.ClientReferenceInformation = &ClientReferenceInformation{
-			Code: *voidRequest.ClientTransactionReference,
+			Code: *voidRequest.MerchantOrderReference,
 		}
+	}
+	if voidRequest.ClientTransactionReference != nil {
+		request.MerchantDefinedInformation = append(request.MerchantDefinedInformation, MerchantDefinedInformation{
+			Key: "1",
+			Value: *voidRequest.ClientTransactionReference,
+		})
 	}
 	return request, nil
 }
@@ -172,10 +184,16 @@ func buildRefundRequest(refundRequest *sleet.RefundRequest) (*Request, error) {
 			},
 		},
 	}
-	if refundRequest.ClientTransactionReference != nil {
+	if refundRequest.MerchantOrderReference != nil {
 		request.ClientReferenceInformation = &ClientReferenceInformation{
-			Code: *refundRequest.ClientTransactionReference,
+			Code: *refundRequest.MerchantOrderReference,
 		}
+	}
+	if refundRequest.ClientTransactionReference != nil {
+		request.MerchantDefinedInformation = append(request.MerchantDefinedInformation, MerchantDefinedInformation{
+			Key: "1",
+			Value: *refundRequest.ClientTransactionReference,
+		})
 	}
 	return request, nil
 }

--- a/types.go
+++ b/types.go
@@ -120,6 +120,7 @@ type CaptureRequest struct {
 	Amount                     *Amount
 	TransactionReference       string
 	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
+	MerchantOrderReference     *string // Custom merchant order reference that will be associated with this request
 }
 
 // CaptureResponse will have Success be true if transaction is captured and also a reference to be used for subsequent operations
@@ -133,6 +134,7 @@ type CaptureResponse struct {
 type VoidRequest struct {
 	TransactionReference       string
 	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
+	MerchantOrderReference     *string // Custom merchant order reference that will be associated with this request
 }
 
 // VoidResponse also specifies a transaction reference if PsP uses different transaction references for different states
@@ -147,6 +149,7 @@ type RefundRequest struct {
 	Amount                     *Amount
 	TransactionReference       string
 	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
+	MerchantOrderReference     *string // Custom merchant order reference that will be associated with this request
 	Last4                      string
 	Options                    map[string]interface{}
 }


### PR DESCRIPTION
Add MerchantOrderReference to Cybersource for Capture/Void/Refund to show Display ID corresponding to Auth request.

Test:
- Capture shows correct DisplayID as Authorization

<img width="1787" alt="Screen Shot 2021-12-06 at 5 58 59 PM" src="https://user-images.githubusercontent.com/13541433/144952318-a97a2116-8e68-4aa4-96a9-9896e306240b.png">
<img width="1792" alt="Screen Shot 2021-12-06 at 5 59 25 PM" src="https://user-images.githubusercontent.com/13541433/144952322-8f9eb44b-01e1-4cb1-ae8f-22c989dd1e6b.png">


Related PR:
https://github.com/BoltApp/source/pull/24037 (with more test pictures)