### PR TITLE
Build Adyen ApplePay auth request

### DIFF
--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -70,7 +70,6 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 		ShopperReference: authRequest.ShopperReference,
 	}
 
-	addPaymentMethod(authRequest, request)
 	addPaymentSpecificFields(authRequest, request)
 	addShopperData(authRequest, request)
 	addAddresses(authRequest, request)
@@ -116,8 +115,9 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest, merchantAccount s
 	return request
 }
 
-// addPaymentMethod add payment method to the adyen payment request.
-func addPaymentMethod(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
+// addPaymentSpecificFields adds fields to the Adyen Payment request that are dependent on the payment method
+func addPaymentSpecificFields(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
+	// Add PaymentMethod field
 	if authRequest.Options[applePayTokenOption] != nil {
 		request.PaymentMethod = map[string]interface{}{
 			"type": "applepay",
@@ -132,10 +132,7 @@ func addPaymentMethod(authRequest *sleet.AuthorizationRequest, request *checkout
 			"type":        "scheme",
 		}
 	}
-}
 
-// addPaymentSpecificFields adds fields to the Adyen Payment request that are dependent on the payment method
-func addPaymentSpecificFields(authRequest *sleet.AuthorizationRequest, request *checkout.PaymentRequest) {
 	if authRequest.Cryptogram != "" && authRequest.ECI != "" {
 		// Apple Pay request
 		request.MpiData = &checkout.ThreeDSecureData{

--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -145,7 +145,7 @@ func addPaymentSpecificFields(authRequest *sleet.AuthorizationRequest, request *
 			Eci:                    authRequest.ECI,
 		}
 		request.PaymentMethod["brand"] = "applepay"
-		request.RecurringProcessingModel = recurringProcessingModelSubscription
+		request.RecurringProcessingModel = recurringProcessingModelCardOnFile
 		request.ShopperInteraction = shopperInteractionEcommerce
 	} else if authRequest.CreditCard.CVV != "" {
 		// New customer credit card request

--- a/gateways/adyen/request_builder_test.go
+++ b/gateways/adyen/request_builder_test.go
@@ -24,6 +24,8 @@ func TestBuildAuthRequest(t *testing.T) {
 	requestWithLevel3ItemDiscount := sleet_testing.BaseAuthorizationRequest()
 	requestWithLevel3ItemDiscount.Level3Data = sleet_testing.BaseLevel3Data()
 	requestWithLevel3ItemDiscount.Level3Data.LineItems[0].ItemDiscountAmount.Amount = 100
+	requestWithApplePayToken := sleet_testing.BaseAuthorizationRequest()
+	requestWithApplePayToken.Options["ApplePayToken"] = "test"
 
 	baseWithAydenData := sleet_testing.BaseAuthorizationRequest()
 	enhanceBaseAuthorizationDataWithAdditionalFields(baseWithAydenData)

--- a/gateways/adyen/request_builder_test.go
+++ b/gateways/adyen/request_builder_test.go
@@ -25,7 +25,8 @@ func TestBuildAuthRequest(t *testing.T) {
 	requestWithLevel3ItemDiscount.Level3Data = sleet_testing.BaseLevel3Data()
 	requestWithLevel3ItemDiscount.Level3Data.LineItems[0].ItemDiscountAmount.Amount = 100
 	requestWithApplePayToken := sleet_testing.BaseAuthorizationRequest()
-	requestWithApplePayToken.Options["ApplePayToken"] = "test"
+	requestWithApplePayToken.CreditCard.CVV = ""
+	requestWithApplePayToken.Options = map[string]interface{}{applePayTokenOption: "testApplePayToken"}
 
 	baseWithAydenData := sleet_testing.BaseAuthorizationRequest()
 	enhanceBaseAuthorizationDataWithAdditionalFields(baseWithAydenData)
@@ -236,6 +237,34 @@ func TestBuildAuthRequest(t *testing.T) {
 				RecurringProcessingModel: "Subscription",
 				Reference:                *requestCitiPLCC.ClientTransactionReference,
 				StorePaymentMethod:       true,
+				ShopperReference:         "test",
+			},
+		},
+		{
+			"Basic Auth Request With ApplePayToken",
+			requestWithApplePayToken,
+			&checkout.PaymentRequest{
+				Amount: checkout.Amount{
+					Currency: "USD",
+					Value:    100,
+				},
+				BillingAddress: &checkout.Address{
+					City:            *base.BillingAddress.Locality,
+					Country:         *base.BillingAddress.CountryCode,
+					PostalCode:      *base.BillingAddress.PostalCode,
+					StateOrProvince: *base.BillingAddress.RegionCode,
+					Street:          "Railroad Street",
+					HouseNumberOrName: "7683",
+				},
+				MerchantAccount: "merchant-account",
+				PaymentMethod: map[string]interface{}{
+					"type":        "applepay",
+					"applePayToken": "testApplePayToken",
+				},
+				ShopperInteraction:       "ContAuth",
+				RecurringProcessingModel: "CardOnFile",
+				Reference:                *requestWithApplePayToken.ClientTransactionReference,
+				StorePaymentMethod:       false,
 				ShopperReference:         "test",
 			},
 		},


### PR DESCRIPTION
This diff builds the [adyen apple pay auth request](https://docs.adyen.com/payment-methods/apple-pay/api-only?tab=your-certificate-intro_2#make-payment). The Encrypted ApplePayToken will be passed through sleet's Options map. This is part of the effort to pass ApplePay encrypted token for Adyen (more details documented [here](https://docs.google.com/document/d/13fqmIXnwsS6Sr0pX5xyGeR1mvfR_VWYwpyt1j2UQB80/edit))

TestPlan: unit tests.