### PR TITLE
Fix cases when amount is less 10 cents for NMI

### DIFF
--- a/gateways/nmi/request_builders.go
+++ b/gateways/nmi/request_builders.go
@@ -2,8 +2,10 @@ package nmi
 
 import (
 	"fmt"
-	"github.com/BoltApp/sleet"
 	"strconv"
+
+	"github.com/BoltApp/sleet"
+	"github.com/shopspring/decimal"
 )
 
 // NMI transaction types
@@ -85,7 +87,6 @@ func enableTestMode(testMode bool) *string {
 }
 
 func formatAmount(amountInt int64) *string {
-	amountString := strconv.FormatInt(amountInt, 10)
-	formattedAmount := fmt.Sprintf("%s.%s", amountString[:len(amountString)-2], amountString[len(amountString)-2:])
-	return &formattedAmount
+	formattatedAmount := decimal.NewFromInt(amountInt).Div(decimal.NewFromInt(int64(100))).StringFixed(2)
+	return &formattatedAmount
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/go-cmp v0.5.1
 	github.com/jarcoal/httpmock v1.0.5
 	github.com/rocketgate/rocketgate-go-sdk v0.0.0-20220106233346-17d98d87a0ff
+	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/stripe/stripe-go v70.11.0+incompatible
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rocketgate/rocketgate-go-sdk v0.0.0-20220106233346-17d98d87a0ff h1:KcXYk9nBcMz35HTctRxrTziAjSJUk1Lid5WVaEMjU6w=
 github.com/rocketgate/rocketgate-go-sdk v0.0.0-20220106233346-17d98d87a0ff/go.mod h1:5zfoDg5zWlwcB1SlaOLYa2Hm9YJaQlB7fqccBb6tosg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
Slack thread for context: https://boltpay.slack.com/archives/C02STBR02VB/p1645036179039349
When `amountInt` has less than 2 digits i.e is less than 10, the string format logic cannot handle it. I also don't know if this amount will ever be negative, the NMI docs aren't super clear. 
Using this decimal package should fix the issue.