### PR TITLE
Added partial capture for checkout.com

### DIFF
--- a/gateways/checkoutcom/checkoutcom.go
+++ b/gateways/checkoutcom/checkoutcom.go
@@ -15,26 +15,28 @@ import (
 type CheckoutComClient struct {
 	apiKey     string
 	httpClient *http.Client
+	env        checkout.SupportedEnvironment
 }
 
 const AcceptedStatusCode = 202
 
 // NewClient creates a CheckoutComClient
 // Note: the environment is indicated by the apiKey. See "isSandbox" assignment in checkout.Create.
-func NewClient(apiKey string) *CheckoutComClient {
-	return NewWithHTTPClient(apiKey, common.DefaultHttpClient())
+func NewClient(env common.Environment, apiKey string) *CheckoutComClient {
+	return NewWithHTTPClient(env, apiKey, common.DefaultHttpClient())
 }
 
 // NewWithHTTPClient uses a custom http client for requests
-func NewWithHTTPClient(apiKey string, httpClient *http.Client) *CheckoutComClient {
+func NewWithHTTPClient(env common.Environment, apiKey string, httpClient *http.Client) *CheckoutComClient {
 	return &CheckoutComClient{
 		apiKey:     apiKey,
 		httpClient: httpClient,
+		env:        GetEnv(env),
 	}
 }
 
 func (client *CheckoutComClient) generateCheckoutDCClient() (*payments.Client, error) {
-	config, err := checkout.Create(client.apiKey, nil)
+	config, err := checkout.SdkConfig(common.SPtr(client.apiKey), nil, client.env)
 	if err != nil {
 		return nil, err
 	}

--- a/gateways/checkoutcom/environment.go
+++ b/gateways/checkoutcom/environment.go
@@ -1,0 +1,11 @@
+package checkoutcom
+
+import "github.com/BoltApp/sleet/common"
+import "github.com/checkout/checkout-sdk-go"
+
+func GetEnv(env common.Environment) checkout.SupportedEnvironment {
+	if env == common.Production {
+		return checkout.Production
+	}
+	return checkout.Sandbox
+}

--- a/gateways/checkoutcom/request_builder.go
+++ b/gateways/checkoutcom/request_builder.go
@@ -88,6 +88,7 @@ func buildRefundParams(refundRequest *sleet.RefundRequest) (*payments.RefundsReq
 func buildCaptureParams(captureRequest *sleet.CaptureRequest) (*payments.CapturesRequest, error) {
 	request := &payments.CapturesRequest{
 		Amount:    uint64(captureRequest.Amount.Amount),
+		CaptureType: payments.NonFinal,
 	}
 
 	if captureRequest.MerchantOrderReference != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BoltApp/braintree-go v0.26.0
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/adyen/adyen-go-api-library/v4 v4.0.0
-	github.com/checkout/checkout-sdk-go v0.0.19
+	github.com/checkout/checkout-sdk-go v0.0.21
 	github.com/go-playground/form v3.1.4+incompatible
 	github.com/go-test/deep v1.0.7
 	github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.5.1
 	github.com/jarcoal/httpmock v1.0.5
 	github.com/rocketgate/rocketgate-go-sdk v0.0.0-20220106233346-17d98d87a0ff
-	github.com/shopspring/decimal v1.3.1 // indirect
+	github.com/shopspring/decimal v1.3.1
 	github.com/stripe/stripe-go v70.11.0+incompatible
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqC
 github.com/adyen/adyen-go-api-library/v4 v4.0.0 h1:zNXA984f8PW/ygW+MwzXIp1A0mAFwdJ5qCAsFxiganU=
 github.com/adyen/adyen-go-api-library/v4 v4.0.0/go.mod h1:OpD0jxx7ObTThFu4Xg7PZID/Gr8LB7FaX+jutrJfUYw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/checkout/checkout-sdk-go v0.0.19 h1:T9HVkUCyrpTkC5DGu5ZmmdjuQs1JDpseJvdYxb1NNpk=
-github.com/checkout/checkout-sdk-go v0.0.19/go.mod h1:lPJ9QLwgdZZPdT7UJgfSRQSG6ygSVBFbU/xVb6QLI30=
+github.com/checkout/checkout-sdk-go v0.0.21 h1:gtndHDuBLLM4VPLSnGQbeoOjsGUYvuEjUQCc7EigE64=
+github.com/checkout/checkout-sdk-go v0.0.21/go.mod h1:8nX+8d2K+vvK/ROMXpCe8ds5T+nbv3LMlyKS9dbU1VU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -110,6 +110,8 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=


### PR DESCRIPTION
Added partial capture for checkout.com
- updated SDK to pick up partial capture feature
- updated usage of SDK from previous update
- added non-final classification to all checkout.com capture requests. Final voids any remaining authorized amount. Non-final leaves the remaining amount to be voided or captured later.