### PR TITLE
Add `go` syntax highlight to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Then run tests with: `go test ./integration-tests/`
 
 ## Code Example for Auth + Capture
 
-```
+```go
 import (
   "github.com/BoltApp/sleet"
   "github.com/BoltApp/sleet/gateways/authorize_net"


### PR DESCRIPTION
This PR proposes that `go` syntax highlight be added to readme example.

See the rendered change here: [`README.md`](https://github.com/BoltApp/sleet/blob/31eb4b96af132a1cea1ef9a4e9c9cadf8dfeaef2/README.md)