### PR TITLE
Allow MPC support for cybersource

### DIFF
--- a/gateways/cybersource/request_builder_test.go
+++ b/gateways/cybersource/request_builder_test.go
@@ -1,5 +1,3 @@
-// +build unit
-
 package cybersource
 
 import (
@@ -43,9 +41,9 @@ func TestBuildAuthRequest(t *testing.T) {
 					CommerceIndicator: "internet",
 					AuthorizationOptions: &AuthorizationOptions{
 						Initiator: &Initiator{
-							InitiatorType: "",
+							InitiatorType:          "",
 							CredentialStoredOnFile: false,
-							StoredCredentialUsed: false,
+							StoredCredentialUsed:   false,
 						},
 					},
 				},
@@ -98,25 +96,25 @@ func TestBuildAuthRequest(t *testing.T) {
 					CommerceIndicator: "internet",
 					AuthorizationOptions: &AuthorizationOptions{
 						Initiator: &Initiator{
-							InitiatorType: "",
+							InitiatorType:          "",
 							CredentialStoredOnFile: false,
-							StoredCredentialUsed: false,
+							StoredCredentialUsed:   false,
 						},
 					},
-					PaymentSolution: "001",	// Apple pay
+					PaymentSolution: "001", // Apple pay
 				},
 				PaymentInformation: &PaymentInformation{
 					TokenizedCard: &TokenizedCard{
-						Number:   visaApplepayBase.CreditCard.Number,
+						Number:          visaApplepayBase.CreditCard.Number,
 						ExpirationYear:  strconv.Itoa(visaApplepayBase.CreditCard.ExpirationYear),
 						ExpirationMonth: fmt.Sprintf("%02d", visaApplepayBase.CreditCard.ExpirationMonth),
 						TransactionType: "1",
-						Cryptogram: visaApplepayBase.Cryptogram,
-						Type: "001",
+						Cryptogram:      visaApplepayBase.Cryptogram,
+						Type:            "001",
 					},
 				},
 				ConsumerAuthenticationInformation: &ConsumerAuthenticationInformation{
-					Xid: visaApplepayBase.Cryptogram,
+					Xid:  visaApplepayBase.Cryptogram,
 					Cavv: visaApplepayBase.Cryptogram,
 				},
 				OrderInformation: &OrderInformation{
@@ -160,25 +158,25 @@ func TestBuildAuthRequest(t *testing.T) {
 					CommerceIndicator: "spa",
 					AuthorizationOptions: &AuthorizationOptions{
 						Initiator: &Initiator{
-							InitiatorType: "",
+							InitiatorType:          "",
 							CredentialStoredOnFile: false,
-							StoredCredentialUsed: false,
+							StoredCredentialUsed:   false,
 						},
 					},
-					PaymentSolution: "001",	// Apple pay
+					PaymentSolution: "001", // Apple pay
 				},
 				PaymentInformation: &PaymentInformation{
 					TokenizedCard: &TokenizedCard{
-						Number:   mastercardApplepayBase.CreditCard.Number,
+						Number:          mastercardApplepayBase.CreditCard.Number,
 						ExpirationYear:  strconv.Itoa(mastercardApplepayBase.CreditCard.ExpirationYear),
 						ExpirationMonth: fmt.Sprintf("%02d", mastercardApplepayBase.CreditCard.ExpirationMonth),
 						TransactionType: "1",
-						Cryptogram: mastercardApplepayBase.Cryptogram,
-						Type: "002",
+						Cryptogram:      mastercardApplepayBase.Cryptogram,
+						Type:            "002",
 					},
 				},
 				ConsumerAuthenticationInformation: &ConsumerAuthenticationInformation{
-					UcafAuthenticationData: mastercardApplepayBase.Cryptogram,
+					UcafAuthenticationData:  mastercardApplepayBase.Cryptogram,
 					UcafCollectionIndicator: "2",
 				},
 				OrderInformation: &OrderInformation{
@@ -222,21 +220,21 @@ func TestBuildAuthRequest(t *testing.T) {
 					CommerceIndicator: "dipb",
 					AuthorizationOptions: &AuthorizationOptions{
 						Initiator: &Initiator{
-							InitiatorType: "",
+							InitiatorType:          "",
 							CredentialStoredOnFile: false,
-							StoredCredentialUsed: false,
+							StoredCredentialUsed:   false,
 						},
 					},
-					PaymentSolution: "001",	// Apple pay
+					PaymentSolution: "001", // Apple pay
 				},
 				PaymentInformation: &PaymentInformation{
 					TokenizedCard: &TokenizedCard{
-						Number:   discoverApplepayBase.CreditCard.Number,
+						Number:          discoverApplepayBase.CreditCard.Number,
 						ExpirationYear:  strconv.Itoa(discoverApplepayBase.CreditCard.ExpirationYear),
 						ExpirationMonth: fmt.Sprintf("%02d", discoverApplepayBase.CreditCard.ExpirationMonth),
 						TransactionType: "1",
-						Cryptogram: discoverApplepayBase.Cryptogram,
-						Type: "004",
+						Cryptogram:      discoverApplepayBase.Cryptogram,
+						Type:            "004",
 					},
 				},
 				ConsumerAuthenticationInformation: &ConsumerAuthenticationInformation{
@@ -283,21 +281,21 @@ func TestBuildAuthRequest(t *testing.T) {
 					CommerceIndicator: "aesk",
 					AuthorizationOptions: &AuthorizationOptions{
 						Initiator: &Initiator{
-							InitiatorType: "",
+							InitiatorType:          "",
 							CredentialStoredOnFile: false,
-							StoredCredentialUsed: false,
+							StoredCredentialUsed:   false,
 						},
 					},
-					PaymentSolution: "001",	// Apple pay
+					PaymentSolution: "001", // Apple pay
 				},
 				PaymentInformation: &PaymentInformation{
 					TokenizedCard: &TokenizedCard{
-						Number:   amexApplepayBase.CreditCard.Number,
+						Number:          amexApplepayBase.CreditCard.Number,
 						ExpirationYear:  strconv.Itoa(amexApplepayBase.CreditCard.ExpirationYear),
 						ExpirationMonth: fmt.Sprintf("%02d", amexApplepayBase.CreditCard.ExpirationMonth),
 						TransactionType: "1",
-						Cryptogram: amexApplepayBase.Cryptogram,
-						Type: "003",
+						Cryptogram:      amexApplepayBase.Cryptogram,
+						Type:            "003",
 					},
 				},
 				ConsumerAuthenticationInformation: &ConsumerAuthenticationInformation{
@@ -344,26 +342,26 @@ func TestBuildAuthRequest(t *testing.T) {
 					CommerceIndicator: "aesk",
 					AuthorizationOptions: &AuthorizationOptions{
 						Initiator: &Initiator{
-							InitiatorType: "",
+							InitiatorType:          "",
 							CredentialStoredOnFile: false,
-							StoredCredentialUsed: false,
+							StoredCredentialUsed:   false,
 						},
 					},
-					PaymentSolution: "001",	// Apple pay
+					PaymentSolution: "001", // Apple pay
 				},
 				PaymentInformation: &PaymentInformation{
 					TokenizedCard: &TokenizedCard{
-						Number:   amexLongCryptoApplepayBase.CreditCard.Number,
+						Number:          amexLongCryptoApplepayBase.CreditCard.Number,
 						ExpirationYear:  strconv.Itoa(amexLongCryptoApplepayBase.CreditCard.ExpirationYear),
 						ExpirationMonth: fmt.Sprintf("%02d", amexLongCryptoApplepayBase.CreditCard.ExpirationMonth),
 						TransactionType: "1",
-						Cryptogram: amexLongCryptoApplepayBase.Cryptogram,
-						Type: "003",
+						Cryptogram:      amexLongCryptoApplepayBase.Cryptogram,
+						Type:            "003",
 					},
 				},
 				ConsumerAuthenticationInformation: &ConsumerAuthenticationInformation{
 					Cavv: amexLongCryptoApplepayBase.Cryptogram[:20],
-					Xid: amexLongCryptoApplepayBase.Cryptogram[20:],
+					Xid:  amexLongCryptoApplepayBase.Cryptogram[20:],
 				},
 				OrderInformation: &OrderInformation{
 					AmountDetails: AmountDetails{
@@ -415,7 +413,7 @@ func TestBuildCaptureRequest(t *testing.T) {
 		{
 			"Basic Capture Request",
 			base,
-			&Request {
+			&Request{
 				OrderInformation: &OrderInformation{
 					AmountDetails: AmountDetails{
 						Amount:   "1.00",
@@ -534,4 +532,52 @@ func getBaseAuthorizationRequest(network sleet.CreditCardNetwork, cryptogram str
 	}
 
 	return base
+}
+
+func TestBuildCaptureRequestWithOptions(t *testing.T) {
+	base := sleet_testing.BaseCaptureRequestWithOptions()
+	base.MerchantOrderReference = common.SPtr("cart_display_id")
+
+	cases := []struct {
+		label string
+		in    *sleet.CaptureRequest
+		want  *Request
+	}{
+		{
+			"Basic Capture Request with options",
+			base,
+			&Request{
+				OrderInformation: &OrderInformation{
+					AmountDetails: AmountDetails{
+						Amount:   "1.00",
+						Currency: "USD",
+					},
+				},
+				ClientReferenceInformation: &ClientReferenceInformation{
+					Code: *base.MerchantOrderReference,
+				},
+				MerchantDefinedInformation: []MerchantDefinedInformation{
+					{
+						Key:   "1",
+						Value: *base.ClientTransactionReference,
+					},
+				},
+				ProcessingInformation: &ProcessingInformation{
+					CaptureOptions: &CaptureOptions{
+						CaptureSequenceNumber: "11",
+						TotalCaptureCount:     "99",
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			got, _ := buildCaptureRequest(c.in)
+			if diff := deep.Equal(got, c.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
 }

--- a/gateways/cybersource/request_builders.go
+++ b/gateways/cybersource/request_builders.go
@@ -179,12 +179,16 @@ func buildCaptureRequest(captureRequest *sleet.CaptureRequest) (*Request, error)
 			Value: *captureRequest.ClientTransactionReference,
 		})
 	}
-	if captureRequest.Options[captureSequenceNumber] != nil && captureRequest.Options[totalCaptureCount] != nil {
-		request.ProcessingInformation = &ProcessingInformation{
-			CaptureOptions: &CaptureOptions{
-				CaptureSequenceNumber: captureRequest.Options[captureSequenceNumber].(string),
-				TotalCaptureCount:     captureRequest.Options[totalCaptureCount].(string),
-			},
+	captureSeqNum, ok := captureRequest.Options[captureSequenceNumber]
+	if ok {
+		totalCapCount, ok := captureRequest.Options[totalCaptureCount]
+		if ok {
+			request.ProcessingInformation = &ProcessingInformation{
+				CaptureOptions: &CaptureOptions{
+					CaptureSequenceNumber: captureSeqNum.(string),
+					TotalCaptureCount:     totalCapCount.(string),
+				},
+			}
 		}
 	}
 	return request, nil

--- a/gateways/cybersource/request_builders.go
+++ b/gateways/cybersource/request_builders.go
@@ -17,8 +17,14 @@ const (
 const (
 	AmexCryptogramMaxLength   = 40
 	AmexCryptogramSplitLength = 20
-	TransactionTypeInApp = "1"
-	PaymentSolutionApplepay = "001"
+	TransactionTypeInApp      = "1"
+	PaymentSolutionApplepay   = "001"
+)
+
+// Options
+const (
+	captureSequenceNumber = "captureSequenceNumber"
+	totalCaptureCount     = "totalCaptureCount"
 )
 
 // add mappings
@@ -69,9 +75,9 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest) (*Request, error)
 			CommerceIndicator: string(CommerceIndicatorInternet),
 			AuthorizationOptions: &AuthorizationOptions{
 				Initiator: &Initiator{
-					InitiatorType: initiatorType,
+					InitiatorType:          initiatorType,
 					CredentialStoredOnFile: credentialStoredOnFile,
-					StoredCredentialUsed: storedCredentialUsed,
+					StoredCredentialUsed:   storedCredentialUsed,
 				},
 			},
 		},
@@ -114,7 +120,7 @@ func buildAuthRequest(authRequest *sleet.AuthorizationRequest) (*Request, error)
 	// If level 3 data is present, and ClientReferenceInformation in that data exists, it will override this.
 	if authRequest.ClientTransactionReference != nil {
 		request.MerchantDefinedInformation = append(request.MerchantDefinedInformation, MerchantDefinedInformation{
-			Key: "1",
+			Key:   "1",
 			Value: *authRequest.ClientTransactionReference,
 		})
 	}
@@ -169,9 +175,17 @@ func buildCaptureRequest(captureRequest *sleet.CaptureRequest) (*Request, error)
 	}
 	if captureRequest.ClientTransactionReference != nil {
 		request.MerchantDefinedInformation = append(request.MerchantDefinedInformation, MerchantDefinedInformation{
-			Key: "1",
+			Key:   "1",
 			Value: *captureRequest.ClientTransactionReference,
 		})
+	}
+	if captureRequest.Options[captureSequenceNumber] != nil && captureRequest.Options[totalCaptureCount] != nil {
+		request.ProcessingInformation = &ProcessingInformation{
+			CaptureOptions: &CaptureOptions{
+				CaptureSequenceNumber: captureRequest.Options[captureSequenceNumber].(string),
+				TotalCaptureCount:     captureRequest.Options[totalCaptureCount].(string),
+			},
+		}
 	}
 	return request, nil
 }
@@ -186,7 +200,7 @@ func buildVoidRequest(voidRequest *sleet.VoidRequest) (*Request, error) {
 	}
 	if voidRequest.ClientTransactionReference != nil {
 		request.MerchantDefinedInformation = append(request.MerchantDefinedInformation, MerchantDefinedInformation{
-			Key: "1",
+			Key:   "1",
 			Value: *voidRequest.ClientTransactionReference,
 		})
 	}
@@ -210,7 +224,7 @@ func buildRefundRequest(refundRequest *sleet.RefundRequest) (*Request, error) {
 	}
 	if refundRequest.ClientTransactionReference != nil {
 		request.MerchantDefinedInformation = append(request.MerchantDefinedInformation, MerchantDefinedInformation{
-			Key: "1",
+			Key:   "1",
 			Value: *refundRequest.ClientTransactionReference,
 		})
 	}
@@ -220,11 +234,11 @@ func buildRefundRequest(refundRequest *sleet.RefundRequest) (*Request, error) {
 func buildApplepayRequest(authRequest *sleet.AuthorizationRequest, request *Request) error {
 	request.PaymentInformation = &PaymentInformation{
 		TokenizedCard: &TokenizedCard{
-			Number: authRequest.CreditCard.Number,
-			ExpirationYear: strconv.Itoa(authRequest.CreditCard.ExpirationYear),
+			Number:          authRequest.CreditCard.Number,
+			ExpirationYear:  strconv.Itoa(authRequest.CreditCard.ExpirationYear),
 			ExpirationMonth: fmt.Sprintf("%02d", authRequest.CreditCard.ExpirationMonth),
 			TransactionType: TransactionTypeInApp,
-			Cryptogram: authRequest.Cryptogram,
+			Cryptogram:      authRequest.Cryptogram,
 		},
 	}
 
@@ -234,14 +248,14 @@ func buildApplepayRequest(authRequest *sleet.AuthorizationRequest, request *Requ
 	case sleet.CreditCardNetworkVisa:
 		request.PaymentInformation.TokenizedCard.Type = string(CardTypeVisa)
 		request.ConsumerAuthenticationInformation = &ConsumerAuthenticationInformation{
-			Xid: authRequest.Cryptogram,
+			Xid:  authRequest.Cryptogram,
 			Cavv: authRequest.Cryptogram,
 		}
 	case sleet.CreditCardNetworkMastercard:
 		request.PaymentInformation.TokenizedCard.Type = string(CardTypeMastercard)
 		request.ProcessingInformation.CommerceIndicator = string(CommerceIndicatorMastercard)
 		request.ConsumerAuthenticationInformation = &ConsumerAuthenticationInformation{
-			UcafAuthenticationData: authRequest.Cryptogram,
+			UcafAuthenticationData:  authRequest.Cryptogram,
 			UcafCollectionIndicator: "2",
 		}
 	case sleet.CreditCardNetworkAmex:
@@ -274,7 +288,7 @@ func getAmexConsumerAuthInfo(cryptogram string) (*ConsumerAuthenticationInformat
 		// the xid field.
 		return &ConsumerAuthenticationInformation{
 			Cavv: cryptogram[:AmexCryptogramSplitLength],
-			Xid: cryptogram[AmexCryptogramSplitLength:],
+			Xid:  cryptogram[AmexCryptogramSplitLength:],
 		}, nil
 	}
 

--- a/gateways/cybersource/types.go
+++ b/gateways/cybersource/types.go
@@ -88,7 +88,6 @@ type ProcessorInformation struct {
 type ProcessingInformation struct {
 	Capture              bool                  `json:"capture,omitempty"`
 	CommerceIndicator    string                `json:"commerceIndicator"` // typically internet
-	CaptureOptions       *CaptureOptions       `json:"captureOptions,omitempty"`
 	PaymentSolution      string                `json:"paymentSolution"`
 	PurchaseLevel        string                `json:"purchaseLevel,omitempty"` // Specifies if level 3 data is being sent
 	AuthorizationOptions *AuthorizationOptions `json:"authorizationOptions,omitempty"`
@@ -217,9 +216,4 @@ type ConsumerAuthenticationInformation struct {
 	UcafCollectionIndicator string `json:"ucafCollectionIndicator,omitempty"`
 	Xid                     string `json:"xid,omitempty"`
 	Cavv                    string `json:"cavv,omitempty"`
-}
-
-type CaptureOptions struct {
-	CaptureSequenceNumber string `json:"captureSequenceNumber,omitempty"`
-	TotalCaptureCount     string `json:"totalCaptureCount,omitempty"`
 }

--- a/gateways/cybersource/types.go
+++ b/gateways/cybersource/types.go
@@ -87,6 +87,7 @@ type ProcessorInformation struct {
 // ProcessingInformation specifies various fields for authorize for options (auto-capture, Level3 Data, etc)
 type ProcessingInformation struct {
 	Capture              bool                  `json:"capture,omitempty"`
+	CaptureOptions       *CaptureOptions       `json:"captureOptions,omitempty"`
 	CommerceIndicator    string                `json:"commerceIndicator"` // typically internet
 	PaymentSolution      string                `json:"paymentSolution"`
 	PurchaseLevel        string                `json:"purchaseLevel,omitempty"` // Specifies if level 3 data is being sent
@@ -216,4 +217,9 @@ type ConsumerAuthenticationInformation struct {
 	UcafCollectionIndicator string `json:"ucafCollectionIndicator,omitempty"`
 	Xid                     string `json:"xid,omitempty"`
 	Cavv                    string `json:"cavv,omitempty"`
+}
+
+type CaptureOptions struct {
+	CaptureSequenceNumber string `json:"captureSequenceNumber,omitempty"`
+	TotalCaptureCount     string `json:"totalCaptureCount,omitempty"`
 }

--- a/gateways/cybersource/types.go
+++ b/gateways/cybersource/types.go
@@ -88,6 +88,7 @@ type ProcessorInformation struct {
 type ProcessingInformation struct {
 	Capture              bool                  `json:"capture,omitempty"`
 	CommerceIndicator    string                `json:"commerceIndicator"` // typically internet
+	CaptureOptions       *CaptureOptions       `json:"captureOptions,omitempty"`
 	PaymentSolution      string                `json:"paymentSolution"`
 	PurchaseLevel        string                `json:"purchaseLevel,omitempty"` // Specifies if level 3 data is being sent
 	AuthorizationOptions *AuthorizationOptions `json:"authorizationOptions,omitempty"`
@@ -216,4 +217,9 @@ type ConsumerAuthenticationInformation struct {
 	UcafCollectionIndicator string `json:"ucafCollectionIndicator,omitempty"`
 	Xid                     string `json:"xid,omitempty"`
 	Cavv                    string `json:"cavv,omitempty"`
+}
+
+type CaptureOptions struct {
+	CaptureSequenceNumber string `json:"captureSequenceNumber,omitempty"`
+	TotalCaptureCount     string `json:"totalCaptureCount,omitempty"`
 }

--- a/testing/auth_request.go
+++ b/testing/auth_request.go
@@ -190,3 +190,21 @@ func Base3DS() *sleet.ThreeDS {
 		XID:              "xid",
 	}
 }
+
+func BaseCaptureRequestWithOptions() *sleet.CaptureRequest {
+	clientRef := "222222"
+
+	amount := sleet.Amount{
+		Amount:   100,
+		Currency: "USD",
+	}
+	return &sleet.CaptureRequest{
+		Amount:                     &amount,
+		TransactionReference:       "111111",
+		ClientTransactionReference: &clientRef,
+		Options: map[string]interface{}{
+			"captureSequenceNumber": "11",
+			"totalCaptureCount":     "99",
+		},
+	}
+}

--- a/types.go
+++ b/types.go
@@ -79,17 +79,17 @@ type Level3Data struct {
 type AuthorizationRequest struct {
 	Amount                        Amount
 	BillingAddress                *Address
-	Channel                       string                   // for PSPs that track the sales channel
-	ClientTransactionReference    *string                  // Custom transaction reference metadata that will be associated with this request
+	Channel                       string  // for PSPs that track the sales channel
+	ClientTransactionReference    *string // Custom transaction reference metadata that will be associated with this request
 	CreditCard                    *CreditCard
-	Cryptogram                    string                   // for Network Tokenization methods
-	ECI                           string                   // E-Commerce Indicator (can be used for Network Tokenization as well)
+	Cryptogram                    string // for Network Tokenization methods
+	ECI                           string // E-Commerce Indicator (can be used for Network Tokenization as well)
 	Level3Data                    *Level3Data
 	MerchantOrderReference        string                   // Similar to ClientTransactionReference but specifically if we want to store the shopping cart order id
 	PreviousExternalTransactionID *string                  // If we are in a recurring situation, then we can use the PreviousExternalTransactionID as part of the auth request
 	ProcessingInitiator           *ProcessingInitiatorType // For Card on File transactions we want to store the various different types (initial cof, initial recurring, etc)
 	ShippingAddress               *Address
-	ShopperReference              string                   // ShopperReference Unique reference to a shopper (shopperId, etc.)
+	ShopperReference              string // ShopperReference Unique reference to a shopper (shopperId, etc.)
 	ThreeDS                       *ThreeDS
 
 	Options map[string]interface{}
@@ -113,15 +113,16 @@ type AuthorizationResponse struct {
 	AvsResultRaw          string
 	CvvResultRaw          string
 	RTAUResult            *RTAUResponse
-	AdyenAdditionalData   map[string]string      // store additional recurring info (will be refactored to general naming on next major version upgrade)
+	AdyenAdditionalData   map[string]string // store additional recurring info (will be refactored to general naming on next major version upgrade)
 }
 
 // CaptureRequest specifies the authorized transaction to capture and also an amount for partial capture use cases
 type CaptureRequest struct {
 	Amount                     *Amount
 	TransactionReference       string
-	ClientTransactionReference *string // Custom transaction reference metadata that will be associated with this request
-	MerchantOrderReference     *string // Custom merchant order reference that will be associated with this request
+	ClientTransactionReference *string                // Custom transaction reference metadata that will be associated with this request
+	MerchantOrderReference     *string                // Custom merchant order reference that will be associated with this request
+	Options                    map[string]interface{} // For additional options that need to be passed in
 }
 
 // CaptureResponse will have Success be true if transaction is captured and also a reference to be used for subsequent operations


### PR DESCRIPTION
We need to send 2 additional fields if we are doing multiple partial captures for Cybersource.
This is specific to first data north but that logic will live in hail.