### PR TITLE
Add http status code to AuthorizationResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,15 @@ address := sleet.BillingAddress{
   PostalCode:     &postalCode,
   CountryCode:    &countryCode,
 }
+// To get specific response headers, add them to the request options.
+// They will be attached to the AuthorizationResponse
+options := make(map[string]interface{})
+options["ResponseHeader"] = []string{"x-test-header"}
 authorizeRequest := sleet.AuthorizationRequest{
   Amount: &amount,
   CreditCard: &card,
   BillingAddress: &address,
+  Options: options,
 }
 authorizeResponse, _ := client.Authorize(&authorizeRequest)
 

--- a/gateways/adyen/adyen.go
+++ b/gateways/adyen/adyen.go
@@ -50,12 +50,12 @@ func (client *AdyenClient) Authorize(request *sleet.AuthorizationRequest) (*slee
 	},
 	)
 
-	// potentially do something with http response
 	result, httpResp, err := adyenClient.Checkout.Payments(buildAuthRequest(request, client.merchantAccount))
 	var statusCode int
-	if httpResp != nil && !sleet.IsTokenizerProxyError(httpResp.Header) {
+	if httpResp != nil {
 		statusCode = httpResp.StatusCode
 	}
+	responseHeader := sleet.GetHTTPResponseHeader(request.Options, *httpResp)
 	if err != nil {
 		return &sleet.AuthorizationResponse{
 			Success:              false,
@@ -63,12 +63,14 @@ func (client *AdyenClient) Authorize(request *sleet.AuthorizationRequest) (*slee
 			AvsResult:            sleet.AVSResponseUnknown,
 			CvvResult:            sleet.CVVResponseUnknown,
 			StatusCode:           statusCode,
+			ResponseHeader:       responseHeader,
 		}, err
 	}
 
 	response := &sleet.AuthorizationResponse{
 		TransactionReference: result.PspReference,
 		StatusCode:           statusCode,
+		ResponseHeader:       responseHeader,
 	}
 	if result.AdditionalData != nil {
 		values, ok := result.AdditionalData.(map[string]interface{})

--- a/gateways/adyen/adyen.go
+++ b/gateways/adyen/adyen.go
@@ -62,13 +62,13 @@ func (client *AdyenClient) Authorize(request *sleet.AuthorizationRequest) (*slee
 			TransactionReference: "",
 			AvsResult:            sleet.AVSResponseUnknown,
 			CvvResult:            sleet.CVVResponseUnknown,
-			StatusCodeRaw:        statusCode,
+			StatusCode:           statusCode,
 		}, err
 	}
 
 	response := &sleet.AuthorizationResponse{
 		TransactionReference: result.PspReference,
-		StatusCodeRaw:        statusCode,
+		StatusCode:           statusCode,
 	}
 	if result.AdditionalData != nil {
 		values, ok := result.AdditionalData.(map[string]interface{})

--- a/gateways/adyen/adyen.go
+++ b/gateways/adyen/adyen.go
@@ -51,18 +51,24 @@ func (client *AdyenClient) Authorize(request *sleet.AuthorizationRequest) (*slee
 	)
 
 	// potentially do something with http response
-	result, _, err := adyenClient.Checkout.Payments(buildAuthRequest(request, client.merchantAccount))
+	result, httpResp, err := adyenClient.Checkout.Payments(buildAuthRequest(request, client.merchantAccount))
+	var statusCode int
+	if httpResp != nil {
+		statusCode = httpResp.StatusCode
+	}
 	if err != nil {
 		return &sleet.AuthorizationResponse{
 			Success:              false,
 			TransactionReference: "",
 			AvsResult:            sleet.AVSResponseUnknown,
 			CvvResult:            sleet.CVVResponseUnknown,
+			StatusCode:           statusCode,
 		}, err
 	}
 
 	response := &sleet.AuthorizationResponse{
 		TransactionReference: result.PspReference,
+		StatusCode:           statusCode,
 	}
 	if result.AdditionalData != nil {
 		values, ok := result.AdditionalData.(map[string]interface{})

--- a/gateways/adyen/adyen.go
+++ b/gateways/adyen/adyen.go
@@ -53,7 +53,7 @@ func (client *AdyenClient) Authorize(request *sleet.AuthorizationRequest) (*slee
 	// potentially do something with http response
 	result, httpResp, err := adyenClient.Checkout.Payments(buildAuthRequest(request, client.merchantAccount))
 	var statusCode int
-	if httpResp != nil {
+	if httpResp != nil && !sleet.IsTokenizerProxyError(httpResp.Header) {
 		statusCode = httpResp.StatusCode
 	}
 	if err != nil {
@@ -62,13 +62,13 @@ func (client *AdyenClient) Authorize(request *sleet.AuthorizationRequest) (*slee
 			TransactionReference: "",
 			AvsResult:            sleet.AVSResponseUnknown,
 			CvvResult:            sleet.CVVResponseUnknown,
-			StatusCode:           statusCode,
+			StatusCodeRaw:        statusCode,
 		}, err
 	}
 
 	response := &sleet.AuthorizationResponse{
 		TransactionReference: result.PspReference,
-		StatusCode:           statusCode,
+		StatusCodeRaw:        statusCode,
 	}
 	if result.AdditionalData != nil {
 		values, ok := result.AdditionalData.(map[string]interface{})

--- a/gateways/adyen/adyen.go
+++ b/gateways/adyen/adyen.go
@@ -63,14 +63,14 @@ func (client *AdyenClient) Authorize(request *sleet.AuthorizationRequest) (*slee
 			AvsResult:            sleet.AVSResponseUnknown,
 			CvvResult:            sleet.CVVResponseUnknown,
 			StatusCode:           statusCode,
-			ResponseHeader:       responseHeader,
+			Header:               responseHeader,
 		}, err
 	}
 
 	response := &sleet.AuthorizationResponse{
 		TransactionReference: result.PspReference,
 		StatusCode:           statusCode,
-		ResponseHeader:       responseHeader,
+		Header:               responseHeader,
 	}
 	if result.AdditionalData != nil {
 		values, ok := result.AdditionalData.(map[string]interface{})

--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -59,7 +59,7 @@ func (client *AuthorizeNetClient) Authorize(request *sleet.AuthorizationRequest)
 		CvvResultRaw:         string(txnResponse.CVVResultCode),
 		Response:             string(txnResponse.ResponseCode),
 		ErrorCode:            errorCode,
-		StatusCodeRaw:        statusCode,
+		StatusCode:           statusCode,
 	}, nil
 }
 

--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -57,7 +57,7 @@ func (client *AuthorizeNetClient) Authorize(request *sleet.AuthorizationRequest)
 		Response:             string(txnResponse.ResponseCode),
 		ErrorCode:            errorCode,
 		StatusCode:           httpResp.StatusCode,
-		ResponseHeader:       responseHeader,
+		Header:               responseHeader,
 	}, nil
 }
 

--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -45,10 +45,7 @@ func (client *AuthorizeNetClient) Authorize(request *sleet.AuthorizationRequest)
 	if txnResponse.ResponseCode != ResponseCodeApproved {
 		errorCode = getErrorCode(txnResponse)
 	}
-	var statusCode int
-	if !sleet.IsTokenizerProxyError(httpResp.Header) {
-		statusCode = httpResp.StatusCode
-	}
+	responseHeader := sleet.GetHTTPResponseHeader(request.Options, *httpResp)
 
 	return &sleet.AuthorizationResponse{
 		Success:              txnResponse.ResponseCode == ResponseCodeApproved || txnResponse.ResponseCode == ResponseCodeHeld,
@@ -59,7 +56,8 @@ func (client *AuthorizeNetClient) Authorize(request *sleet.AuthorizationRequest)
 		CvvResultRaw:         string(txnResponse.CVVResultCode),
 		Response:             string(txnResponse.ResponseCode),
 		ErrorCode:            errorCode,
-		StatusCode:           statusCode,
+		StatusCode:           httpResp.StatusCode,
+		ResponseHeader:       responseHeader,
 	}, nil
 }
 

--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -36,7 +36,7 @@ func NewWithHttpClient(merchantName string, transactionKey string, environment c
 // Authorize a transaction for specified amount using Auth.net REST APIs
 func (client *AuthorizeNetClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
 	authorizeNetAuthorizeRequest := buildAuthRequest(client.merchantName, client.transactionKey, request)
-	response, err := client.sendRequest(*authorizeNetAuthorizeRequest)
+	response, statusCode, err := client.sendRequest(*authorizeNetAuthorizeRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -55,13 +55,14 @@ func (client *AuthorizeNetClient) Authorize(request *sleet.AuthorizationRequest)
 		CvvResultRaw:         string(txnResponse.CVVResultCode),
 		Response:             string(txnResponse.ResponseCode),
 		ErrorCode:            errorCode,
+		StatusCode:           *statusCode,
 	}, nil
 }
 
 // Capture an authorized transaction by transaction reference using the transactionTypePriorAuthCapture flag
 func (client *AuthorizeNetClient) Capture(request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
 	authorizeNetCaptureRequest := buildCaptureRequest(client.merchantName, client.transactionKey, request)
-	authorizeNetResponse, err := client.sendRequest(*authorizeNetCaptureRequest)
+	authorizeNetResponse, _, err := client.sendRequest(*authorizeNetCaptureRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +81,7 @@ func (client *AuthorizeNetClient) Capture(request *sleet.CaptureRequest) (*sleet
 // Void an existing authorized transaction
 func (client *AuthorizeNetClient) Void(request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
 	authorizeNetCaptureRequest := buildVoidRequest(client.merchantName, client.transactionKey, request)
-	authorizeNetResponse, err := client.sendRequest(*authorizeNetCaptureRequest)
+	authorizeNetResponse, _, err := client.sendRequest(*authorizeNetCaptureRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +103,7 @@ func (client *AuthorizeNetClient) Refund(request *sleet.RefundRequest) (*sleet.R
 		return nil, err
 	}
 
-	authorizeNetResponse, err := client.sendRequest(*authorizeNetRefundRequest)
+	authorizeNetResponse, _, err := client.sendRequest(*authorizeNetRefundRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -118,23 +119,23 @@ func (client *AuthorizeNetClient) Refund(request *sleet.RefundRequest) (*sleet.R
 	}, nil
 }
 
-func (client *AuthorizeNetClient) sendRequest(data Request) (*Response, error) {
+func (client *AuthorizeNetClient) sendRequest(data Request) (*Response, *int, error) {
 	bodyJSON, err := json.Marshal(data)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	reader := bytes.NewReader(bodyJSON)
 	request, err := http.NewRequest(http.MethodPost, client.url, reader)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	request.Header.Add("User-Agent", common.UserAgent())
 	request.Header.Add("Content-Type", "application/json")
 
 	resp, err := client.httpClient.Do(request)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer func() {
 		err := resp.Body.Close()
@@ -145,16 +146,16 @@ func (client *AuthorizeNetClient) sendRequest(data Request) (*Response, error) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// trim UTF-8 BOM
 	bodyBytes := bytes.TrimPrefix(body, []byte("\xef\xbb\xbf"))
 	var authorizeNetResponse Response
 	err = json.Unmarshal(bodyBytes, &authorizeNetResponse)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return &authorizeNetResponse, nil
+	return &authorizeNetResponse, &resp.StatusCode, nil
 }
 
 func getErrorCode(txnResponse TransactionResponse) string {

--- a/gateways/authorizenet/authorizenet_test.go
+++ b/gateways/authorizenet/authorizenet_test.go
@@ -94,7 +94,7 @@ func TestAuthorize(t *testing.T) {
 
 	var authResponseRaw []byte
 
-	request := sleet_t.BaseAuthorizationRequest()
+	request := sleet_t.BaseAuthorizationRequestWithResponseHeaderOption()
 
 	t.Run("With Successful Response", func(t *testing.T) {
 		httpmock.Activate()
@@ -104,6 +104,7 @@ func TestAuthorize(t *testing.T) {
 			// TODO check if send json body matches test json body ?
 			authResponseRaw = helper.ReadFile("test_data/authResponse.json")
 			resp := httpmock.NewBytesResponse(http.StatusOK, authResponseRaw)
+			resp.Header = http.Header{"X-Test-Header": {"test_header_value"}}
 			return resp, nil
 		})
 
@@ -116,6 +117,7 @@ func TestAuthorize(t *testing.T) {
 			CvvResultRaw:         "S",
 			Response:             "1",
 			StatusCode:           200,
+			Header:               http.Header{"X-Test-Header": {"test_header_value"}},
 		}
 
 		client := NewClient("MerchantName", "Key", common.Sandbox)
@@ -139,6 +141,7 @@ func TestAuthorize(t *testing.T) {
 		httpmock.RegisterResponder("POST", url, func(req *http.Request) (*http.Response, error) {
 			authResponseRaw = helper.ReadFile("test_data/authDeclineResponse.json")
 			resp := httpmock.NewBytesResponse(http.StatusOK, authResponseRaw)
+			resp.Header = http.Header{"X-Test-Header": {"test_header_value"}}
 			return resp, nil
 		})
 
@@ -152,6 +155,7 @@ func TestAuthorize(t *testing.T) {
 			CvvResultRaw:         "P",
 			Response:             "2",
 			StatusCode:           200,
+			Header:               http.Header{"X-Test-Header": {"test_header_value"}},
 		}
 
 		client := NewClient("MerchantName", "Key", common.Sandbox)

--- a/gateways/authorizenet/authorizenet_test.go
+++ b/gateways/authorizenet/authorizenet_test.go
@@ -74,7 +74,7 @@ func TestSend(t *testing.T) {
 		var want *Response = new(Response)
 		helper.Unmarshal(authResponseRaw, want)
 
-		got, err := client.sendRequest(*request)
+		got, _, err := client.sendRequest(*request)
 
 		if err != nil {
 			t.Fatalf("Error thrown after sending request %q", err)
@@ -115,6 +115,7 @@ func TestAuthorize(t *testing.T) {
 			AvsResultRaw:         "Y",
 			CvvResultRaw:         "S",
 			Response:             "1",
+			StatusCode:           200,
 		}
 
 		client := NewClient("MerchantName", "Key", common.Sandbox)
@@ -150,6 +151,7 @@ func TestAuthorize(t *testing.T) {
 			AvsResultRaw:         "Y",
 			CvvResultRaw:         "P",
 			Response:             "2",
+			StatusCode:           200,
 		}
 
 		client := NewClient("MerchantName", "Key", common.Sandbox)

--- a/gateways/braintree/braintree.go
+++ b/gateways/braintree/braintree.go
@@ -72,7 +72,11 @@ func (client *BraintreeClient) Authorize(request *sleet.AuthorizationRequest) (*
 	btClient := braintree_go.NewWithHttpClient(client.environment, client.merchantID, client.publicKey, client.privateKey, client.httpClient)
 	auth, err := btClient.Transaction().Create(context.TODO(), authRequest)
 	if err != nil {
-		return &sleet.AuthorizationResponse{Success: false}, err
+		var statusCode int
+		if respErr, ok := err.(braintree_go.InvalidResponseError); ok {
+			statusCode = respErr.Response().StatusCode
+		}
+		return &sleet.AuthorizationResponse{Success: false, StatusCode: statusCode}, err
 	}
 
 	avsResult := fmt.Sprintf("%s:%s:%s", auth.AVSErrorResponseCode, auth.AVSStreetAddressResponseCode, auth.AVSStreetAddressResponseCode)

--- a/gateways/braintree/braintree.go
+++ b/gateways/braintree/braintree.go
@@ -76,7 +76,7 @@ func (client *BraintreeClient) Authorize(request *sleet.AuthorizationRequest) (*
 		if respErr, ok := err.(braintree_go.InvalidResponseError); ok {
 			statusCode = respErr.Response().StatusCode
 		}
-		return &sleet.AuthorizationResponse{Success: false, StatusCode: statusCode}, err
+		return &sleet.AuthorizationResponse{Success: false, StatusCodeRaw: statusCode}, err
 	}
 
 	avsResult := fmt.Sprintf("%s:%s:%s", auth.AVSErrorResponseCode, auth.AVSStreetAddressResponseCode, auth.AVSStreetAddressResponseCode)

--- a/gateways/braintree/braintree.go
+++ b/gateways/braintree/braintree.go
@@ -73,7 +73,7 @@ func (client *BraintreeClient) Authorize(request *sleet.AuthorizationRequest) (*
 	auth, err := btClient.Transaction().Create(context.TODO(), authRequest)
 	if err != nil {
 		var statusCode int
-		if respErr, ok := err.(*braintree_go.BraintreeError); ok {
+		if respErr, ok := err.(*braintree_go.BraintreeError); ok && respErr != nil {
 			statusCode = respErr.StatusCode()
 		}
 		return &sleet.AuthorizationResponse{Success: false, StatusCode: statusCode}, err

--- a/gateways/braintree/braintree.go
+++ b/gateways/braintree/braintree.go
@@ -76,7 +76,7 @@ func (client *BraintreeClient) Authorize(request *sleet.AuthorizationRequest) (*
 		if respErr, ok := err.(braintree_go.InvalidResponseError); ok {
 			statusCode = respErr.Response().StatusCode
 		}
-		return &sleet.AuthorizationResponse{Success: false, StatusCodeRaw: statusCode}, err
+		return &sleet.AuthorizationResponse{Success: false, StatusCode: statusCode}, err
 	}
 
 	avsResult := fmt.Sprintf("%s:%s:%s", auth.AVSErrorResponseCode, auth.AVSStreetAddressResponseCode, auth.AVSStreetAddressResponseCode)

--- a/gateways/braintree/braintree.go
+++ b/gateways/braintree/braintree.go
@@ -73,8 +73,8 @@ func (client *BraintreeClient) Authorize(request *sleet.AuthorizationRequest) (*
 	auth, err := btClient.Transaction().Create(context.TODO(), authRequest)
 	if err != nil {
 		var statusCode int
-		if respErr, ok := err.(braintree_go.InvalidResponseError); ok {
-			statusCode = respErr.Response().StatusCode
+		if respErr, ok := err.(*braintree_go.BraintreeError); ok {
+			statusCode = respErr.StatusCode()
 		}
 		return &sleet.AuthorizationResponse{Success: false, StatusCode: statusCode}, err
 	}

--- a/gateways/checkoutcom/checkoutcom.go
+++ b/gateways/checkoutcom/checkoutcom.go
@@ -61,6 +61,10 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 	}
 
 	response, err := checkoutComClient.Request(input, nil)
+	var statusCode int
+	if response != nil && response.StatusResponse != nil {
+		statusCode = response.StatusResponse.StatusCode
+	}
 
 	if err != nil {
 		return &sleet.AuthorizationResponse{
@@ -69,7 +73,7 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 			AvsResult:            sleet.AVSResponseUnknown,
 			CvvResult:            sleet.CVVResponseUnknown,
 			ErrorCode:            err.Error(),
-			StatusCode:           response.StatusResponse.StatusCode,
+			StatusCode:           statusCode,
 		}, err
 	}
 
@@ -82,7 +86,7 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 			AvsResultRaw:         response.Processed.Source.AVSCheck,
 			CvvResultRaw:         response.Processed.Source.CVVCheck,
 			Response:             response.Processed.ResponseCode,
-			StatusCode:           response.StatusResponse.StatusCode,
+			StatusCode:           statusCode,
 		}, nil
 	} else {
 		return &sleet.AuthorizationResponse{
@@ -92,7 +96,7 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 			CvvResult:            sleet.CVVResponseUnknown,
 			Response:             response.Processed.ResponseCode,
 			ErrorCode:            response.Processed.ResponseCode,
-			StatusCode:           response.StatusResponse.StatusCode,
+			StatusCode:           statusCode,
 		}, nil
 	}
 }

--- a/gateways/checkoutcom/checkoutcom.go
+++ b/gateways/checkoutcom/checkoutcom.go
@@ -63,7 +63,14 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 	response, err := checkoutComClient.Request(input, nil)
 
 	if err != nil {
-		return &sleet.AuthorizationResponse{Success: false, TransactionReference: "", AvsResult: sleet.AVSResponseUnknown, CvvResult: sleet.CVVResponseUnknown, ErrorCode: err.Error()}, err
+		return &sleet.AuthorizationResponse{
+			Success:              false,
+			TransactionReference: "",
+			AvsResult:            sleet.AVSResponseUnknown,
+			CvvResult:            sleet.CVVResponseUnknown,
+			ErrorCode:            err.Error(),
+			StatusCode:           response.StatusResponse.StatusCode,
+		}, err
 	}
 
 	if *response.Processed.Approved {
@@ -75,6 +82,7 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 			AvsResultRaw:         response.Processed.Source.AVSCheck,
 			CvvResultRaw:         response.Processed.Source.CVVCheck,
 			Response:             response.Processed.ResponseCode,
+			StatusCode:           response.StatusResponse.StatusCode,
 		}, nil
 	} else {
 		return &sleet.AuthorizationResponse{
@@ -84,6 +92,7 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 			CvvResult:            sleet.CVVResponseUnknown,
 			Response:             response.Processed.ResponseCode,
 			ErrorCode:            response.Processed.ResponseCode,
+			StatusCode:           response.StatusResponse.StatusCode,
 		}, nil
 	}
 }

--- a/gateways/checkoutcom/checkoutcom.go
+++ b/gateways/checkoutcom/checkoutcom.go
@@ -69,7 +69,7 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 			AvsResult:            sleet.AVSResponseUnknown,
 			CvvResult:            sleet.CVVResponseUnknown,
 			ErrorCode:            err.Error(),
-			StatusCode:           response.StatusResponse.StatusCode,
+			StatusCodeRaw:        response.StatusResponse.StatusCode,
 		}, err
 	}
 
@@ -82,7 +82,7 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 			AvsResultRaw:         response.Processed.Source.AVSCheck,
 			CvvResultRaw:         response.Processed.Source.CVVCheck,
 			Response:             response.Processed.ResponseCode,
-			StatusCode:           response.StatusResponse.StatusCode,
+			StatusCodeRaw:        response.StatusResponse.StatusCode,
 		}, nil
 	} else {
 		return &sleet.AuthorizationResponse{
@@ -92,7 +92,7 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 			CvvResult:            sleet.CVVResponseUnknown,
 			Response:             response.Processed.ResponseCode,
 			ErrorCode:            response.Processed.ResponseCode,
-			StatusCode:           response.StatusResponse.StatusCode,
+			StatusCodeRaw:        response.StatusResponse.StatusCode,
 		}, nil
 	}
 }

--- a/gateways/checkoutcom/checkoutcom.go
+++ b/gateways/checkoutcom/checkoutcom.go
@@ -69,7 +69,7 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 			AvsResult:            sleet.AVSResponseUnknown,
 			CvvResult:            sleet.CVVResponseUnknown,
 			ErrorCode:            err.Error(),
-			StatusCodeRaw:        response.StatusResponse.StatusCode,
+			StatusCode:           response.StatusResponse.StatusCode,
 		}, err
 	}
 
@@ -82,7 +82,7 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 			AvsResultRaw:         response.Processed.Source.AVSCheck,
 			CvvResultRaw:         response.Processed.Source.CVVCheck,
 			Response:             response.Processed.ResponseCode,
-			StatusCodeRaw:        response.StatusResponse.StatusCode,
+			StatusCode:           response.StatusResponse.StatusCode,
 		}, nil
 	} else {
 		return &sleet.AuthorizationResponse{
@@ -92,7 +92,7 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 			CvvResult:            sleet.CVVResponseUnknown,
 			Response:             response.Processed.ResponseCode,
 			ErrorCode:            response.Processed.ResponseCode,
-			StatusCodeRaw:        response.StatusResponse.StatusCode,
+			StatusCode:           response.StatusResponse.StatusCode,
 		}, nil
 	}
 }

--- a/gateways/cybersource/cybersource.go
+++ b/gateways/cybersource/cybersource.go
@@ -65,10 +65,10 @@ func (client *CybersourceClient) Authorize(request *sleet.AuthorizationRequest) 
 	// Status 400 or 502 - Failed
 	if cybersourceResponse.ErrorReason != nil {
 		response := sleet.AuthorizationResponse{
-			Success:        false,
-			ErrorCode:      *cybersourceResponse.ErrorReason,
-			StatusCode:     httpResponse.StatusCode,
-			ResponseHeader: responseHeader,
+			Success:    false,
+			ErrorCode:  *cybersourceResponse.ErrorReason,
+			StatusCode: httpResponse.StatusCode,
+			Header:     responseHeader,
 		}
 		return &response, nil
 	}
@@ -89,7 +89,7 @@ func (client *CybersourceClient) Authorize(request *sleet.AuthorizationRequest) 
 		Response:             cybersourceResponse.Status,
 		ErrorCode:            errorCode,
 		StatusCode:           httpResponse.StatusCode,
-		ResponseHeader:       responseHeader,
+		Header:               responseHeader,
 	}
 	if cybersourceResponse.ProcessorInformation != nil {
 		response.AvsResult = translateAvs(cybersourceResponse.ProcessorInformation.AVS.Code)

--- a/gateways/cybersource/cybersource.go
+++ b/gateways/cybersource/cybersource.go
@@ -67,7 +67,7 @@ func (client *CybersourceClient) Authorize(request *sleet.AuthorizationRequest) 
 	}
 	// Status 400 or 502 - Failed
 	if cybersourceResponse.ErrorReason != nil {
-		response := sleet.AuthorizationResponse{Success: false, ErrorCode: *cybersourceResponse.ErrorReason, StatusCodeRaw: statusCode}
+		response := sleet.AuthorizationResponse{Success: false, ErrorCode: *cybersourceResponse.ErrorReason, StatusCode: statusCode}
 		return &response, nil
 	}
 
@@ -86,7 +86,7 @@ func (client *CybersourceClient) Authorize(request *sleet.AuthorizationRequest) 
 		TransactionReference: *cybersourceResponse.ID,
 		Response:             cybersourceResponse.Status,
 		ErrorCode:            errorCode,
-		StatusCodeRaw:        statusCode,
+		StatusCode:           statusCode,
 	}
 	if cybersourceResponse.ProcessorInformation != nil {
 		response.AvsResult = translateAvs(cybersourceResponse.ProcessorInformation.AVS.Code)

--- a/gateways/firstdata/firstdata.go
+++ b/gateways/firstdata/firstdata.go
@@ -72,10 +72,10 @@ func (client *FirstdataClient) Authorize(request *sleet.AuthorizationRequest) (*
 	responseHeader := sleet.GetHTTPResponseHeader(request.Options, *httpResponse)
 	if firstdataResponse.Error != nil {
 		response := sleet.AuthorizationResponse{
-			Success:        false,
-			ErrorCode:      firstdataResponse.Error.Code,
-			StatusCode:     httpResponse.StatusCode,
-			ResponseHeader: responseHeader,
+			Success:    false,
+			ErrorCode:  firstdataResponse.Error.Code,
+			StatusCode: httpResponse.StatusCode,
+			Header:     responseHeader,
 		}
 		return &response, nil
 	}
@@ -95,7 +95,7 @@ func (client *FirstdataClient) Authorize(request *sleet.AuthorizationRequest) (*
 		AvsResultRaw:         fmt.Sprintf("%s:%s", avs.StreetMatch, avs.PostCodeMatch),
 		CvvResultRaw:         string(firstdataResponse.Processor.SecurityCodeResponse),
 		StatusCode:           httpResponse.StatusCode,
-		ResponseHeader:       responseHeader,
+		Header:               responseHeader,
 	}, nil
 }
 

--- a/gateways/firstdata/firstdata.go
+++ b/gateways/firstdata/firstdata.go
@@ -75,7 +75,7 @@ func (client *FirstdataClient) Authorize(request *sleet.AuthorizationRequest) (*
 		statusCode = httpResponse.StatusCode
 	}
 	if firstdataResponse.Error != nil {
-		response := sleet.AuthorizationResponse{Success: false, ErrorCode: firstdataResponse.Error.Code, StatusCodeRaw: statusCode}
+		response := sleet.AuthorizationResponse{Success: false, ErrorCode: firstdataResponse.Error.Code, StatusCode: statusCode}
 		return &response, nil
 	}
 
@@ -93,7 +93,7 @@ func (client *FirstdataClient) Authorize(request *sleet.AuthorizationRequest) (*
 		Response:             string(firstdataResponse.TransactionState),
 		AvsResultRaw:         fmt.Sprintf("%s:%s", avs.StreetMatch, avs.PostCodeMatch),
 		CvvResultRaw:         string(firstdataResponse.Processor.SecurityCodeResponse),
-		StatusCodeRaw:        statusCode,
+		StatusCode:           statusCode,
 	}, nil
 }
 

--- a/gateways/firstdata/firstdata.go
+++ b/gateways/firstdata/firstdata.go
@@ -69,13 +69,14 @@ func (client *FirstdataClient) Authorize(request *sleet.AuthorizationRequest) (*
 	}
 
 	success := false
-
-	var statusCode int
-	if !sleet.IsTokenizerProxyError(httpResponse.Header) {
-		statusCode = httpResponse.StatusCode
-	}
+	responseHeader := sleet.GetHTTPResponseHeader(request.Options, *httpResponse)
 	if firstdataResponse.Error != nil {
-		response := sleet.AuthorizationResponse{Success: false, ErrorCode: firstdataResponse.Error.Code, StatusCode: statusCode}
+		response := sleet.AuthorizationResponse{
+			Success:        false,
+			ErrorCode:      firstdataResponse.Error.Code,
+			StatusCode:     httpResponse.StatusCode,
+			ResponseHeader: responseHeader,
+		}
 		return &response, nil
 	}
 
@@ -93,7 +94,8 @@ func (client *FirstdataClient) Authorize(request *sleet.AuthorizationRequest) (*
 		Response:             string(firstdataResponse.TransactionState),
 		AvsResultRaw:         fmt.Sprintf("%s:%s", avs.StreetMatch, avs.PostCodeMatch),
 		CvvResultRaw:         string(firstdataResponse.Processor.SecurityCodeResponse),
-		StatusCode:           statusCode,
+		StatusCode:           httpResponse.StatusCode,
+		ResponseHeader:       responseHeader,
 	}, nil
 }
 

--- a/gateways/firstdata/firstdata_test.go
+++ b/gateways/firstdata/firstdata_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package firstdata
@@ -144,7 +145,7 @@ func TestSend(t *testing.T) {
 		var want *Response = new(Response)
 		helper.Unmarshal(authResponseRaw, want)
 
-		got, err := firstDataClient.sendRequest(defaultReqId, url, *request)
+		got, _, err := firstDataClient.sendRequest(defaultReqId, url, *request)
 
 		t.Run("Response Struct", func(t *testing.T) {
 			if err != nil {
@@ -204,7 +205,7 @@ func TestSend(t *testing.T) {
 		var want *Response = new(Response)
 		helper.Unmarshal(authErrorRaw, want)
 
-		got, err := firstDataClient.sendRequest(defaultReqId, url, *request)
+		got, _, err := firstDataClient.sendRequest(defaultReqId, url, *request)
 
 		t.Run("Response Struct", func(t *testing.T) {
 			if err != nil {
@@ -254,6 +255,7 @@ func TestAuthorize(t *testing.T) {
 			CvvResult:            sleet.CVVResponseSkipped,
 			AvsResultRaw:         "NO_INPUT_DATA:NO_INPUT_DATA",
 			CvvResultRaw:         "NOT_CHECKED",
+			StatusCode:           200,
 		}
 
 		if !cmp.Equal(*got, *want, sleet_t.CompareUnexported) {
@@ -281,8 +283,9 @@ func TestAuthorize(t *testing.T) {
 		}
 
 		want := &sleet.AuthorizationResponse{
-			Success:   false,
-			ErrorCode: "403",
+			Success:    false,
+			ErrorCode:  "403",
+			StatusCode: 200,
 		}
 
 		if !cmp.Equal(*got, *want, sleet_t.CompareUnexported) {

--- a/gateways/nmi/nmi.go
+++ b/gateways/nmi/nmi.go
@@ -42,7 +42,7 @@ func NewWithHttpClient(env common.Environment, securityKey string, httpClient *h
 func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
 	nmiAuthRequest := buildAuthRequest(client.testMode, client.securityKey, request)
 
-	nmiResponse, err := client.sendRequest(nmiAuthRequest)
+	nmiResponse, statusCode, err := client.sendRequest(nmiAuthRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -50,9 +50,10 @@ func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.
 	// "2" means declined and "3" means bad request
 	if nmiResponse.Response != "1" {
 		return &sleet.AuthorizationResponse{
-			Success:   false,
-			Response:  nmiResponse.ResponseCode,
-			ErrorCode: nmiResponse.ResponseCode,
+			Success:    false,
+			Response:   nmiResponse.ResponseCode,
+			ErrorCode:  nmiResponse.ResponseCode,
+			StatusCode: *statusCode,
 		}, nil
 	}
 
@@ -64,6 +65,7 @@ func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.
 		Response:             nmiResponse.ResponseCode,
 		AvsResultRaw:         nmiResponse.AVSResponseCode,
 		CvvResultRaw:         nmiResponse.CVVResponseCode,
+		StatusCode:           *statusCode,
 	}, nil
 }
 
@@ -72,7 +74,7 @@ func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.
 func (client *NMIClient) Capture(request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
 	nmiCaptureRequest := buildCaptureRequest(client.testMode, client.securityKey, request)
 
-	nmiResponse, err := client.sendRequest(nmiCaptureRequest)
+	nmiResponse, _, err := client.sendRequest(nmiCaptureRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +100,7 @@ func (client *NMIClient) Capture(request *sleet.CaptureRequest) (*sleet.CaptureR
 func (client *NMIClient) Void(request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
 	nmiVoidRequest := buildVoidRequest(client.testMode, client.securityKey, request)
 
-	nmiResponse, err := client.sendRequest(nmiVoidRequest)
+	nmiResponse, _, err := client.sendRequest(nmiVoidRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +127,7 @@ func (client *NMIClient) Void(request *sleet.VoidRequest) (*sleet.VoidResponse, 
 func (client *NMIClient) Refund(request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
 	nmiRefundRequest := buildRefundRequest(client.testMode, client.securityKey, request)
 
-	nmiResponse, err := client.sendRequest(nmiRefundRequest)
+	nmiResponse, _, err := client.sendRequest(nmiRefundRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -148,21 +150,21 @@ func (client *NMIClient) Refund(request *sleet.RefundRequest) (*sleet.RefundResp
 
 // sendRequest sends an API request with the given payload to the NMI transaction endpoint.
 // If the request is successfully sent, its response message will be returned.
-func (client *NMIClient) sendRequest(data *Request) (*Response, error) {
+func (client *NMIClient) sendRequest(data *Request) (*Response, *int, error) {
 	encoder := form.NewEncoder()
 	formData, err := encoder.Encode(data)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	req, err := http.NewRequest(http.MethodPost, transactionEndpoint, strings.NewReader(formData.Encode()))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	parsedUrl, err := url.Parse(transactionEndpoint)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	req.Header.Add("Host", parsedUrl.Hostname())
 	req.Header.Add("User-Agent", common.UserAgent())
@@ -170,7 +172,7 @@ func (client *NMIClient) sendRequest(data *Request) (*Response, error) {
 
 	resp, err := client.httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer func() {
 		err := resp.Body.Close()
@@ -181,18 +183,18 @@ func (client *NMIClient) sendRequest(data *Request) (*Response, error) {
 
 	respBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	parsedFormData, err := url.ParseQuery(string(respBody))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	decoder := form.NewDecoder()
 	nmiResponse := Response{}
 	err = decoder.Decode(&nmiResponse, parsedFormData)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return &nmiResponse, nil
+	return &nmiResponse, &resp.StatusCode, nil
 }

--- a/gateways/nmi/nmi.go
+++ b/gateways/nmi/nmi.go
@@ -54,10 +54,10 @@ func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.
 	// "2" means declined and "3" means bad request
 	if nmiResponse.Response != "1" {
 		return &sleet.AuthorizationResponse{
-			Success:       false,
-			Response:      nmiResponse.ResponseCode,
-			ErrorCode:     nmiResponse.ResponseCode,
-			StatusCodeRaw: statusCode,
+			Success:    false,
+			Response:   nmiResponse.ResponseCode,
+			ErrorCode:  nmiResponse.ResponseCode,
+			StatusCode: statusCode,
 		}, nil
 	}
 
@@ -69,7 +69,7 @@ func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.
 		Response:             nmiResponse.ResponseCode,
 		AvsResultRaw:         nmiResponse.AVSResponseCode,
 		CvvResultRaw:         nmiResponse.CVVResponseCode,
-		StatusCodeRaw:        statusCode,
+		StatusCode:           statusCode,
 	}, nil
 }
 

--- a/gateways/nmi/nmi.go
+++ b/gateways/nmi/nmi.go
@@ -51,11 +51,11 @@ func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.
 	// "2" means declined and "3" means bad request
 	if nmiResponse.Response != "1" {
 		return &sleet.AuthorizationResponse{
-			Success:        false,
-			Response:       nmiResponse.ResponseCode,
-			ErrorCode:      nmiResponse.ResponseCode,
-			StatusCode:     httpResponse.StatusCode,
-			ResponseHeader: responseHeader,
+			Success:    false,
+			Response:   nmiResponse.ResponseCode,
+			ErrorCode:  nmiResponse.ResponseCode,
+			StatusCode: httpResponse.StatusCode,
+			Header:     responseHeader,
 		}, nil
 	}
 
@@ -68,7 +68,7 @@ func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.
 		AvsResultRaw:         nmiResponse.AVSResponseCode,
 		CvvResultRaw:         nmiResponse.CVVResponseCode,
 		StatusCode:           httpResponse.StatusCode,
-		ResponseHeader:       responseHeader,
+		Header:               responseHeader,
 	}, nil
 }
 

--- a/gateways/nmi/nmi.go
+++ b/gateways/nmi/nmi.go
@@ -47,17 +47,15 @@ func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.
 		return nil, err
 	}
 
-	var statusCode int
-	if !sleet.IsTokenizerProxyError(httpResponse.Header) {
-		statusCode = httpResponse.StatusCode
-	}
+	responseHeader := sleet.GetHTTPResponseHeader(request.Options, *httpResponse)
 	// "2" means declined and "3" means bad request
 	if nmiResponse.Response != "1" {
 		return &sleet.AuthorizationResponse{
-			Success:    false,
-			Response:   nmiResponse.ResponseCode,
-			ErrorCode:  nmiResponse.ResponseCode,
-			StatusCode: statusCode,
+			Success:        false,
+			Response:       nmiResponse.ResponseCode,
+			ErrorCode:      nmiResponse.ResponseCode,
+			StatusCode:     httpResponse.StatusCode,
+			ResponseHeader: responseHeader,
 		}, nil
 	}
 
@@ -69,7 +67,8 @@ func (client *NMIClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.
 		Response:             nmiResponse.ResponseCode,
 		AvsResultRaw:         nmiResponse.AVSResponseCode,
 		CvvResultRaw:         nmiResponse.CVVResponseCode,
-		StatusCode:           statusCode,
+		StatusCode:           httpResponse.StatusCode,
+		ResponseHeader:       responseHeader,
 	}, nil
 }
 

--- a/gateways/orbital/orbital.go
+++ b/gateways/orbital/orbital.go
@@ -43,20 +43,29 @@ func (client *OrbitalClient) Authorize(request *sleet.AuthorizationRequest) (*sl
 		return nil, err
 	}
 
-	var statusCode int
-	if !sleet.IsTokenizerProxyError(httpResponse.Header) {
-		statusCode = httpResponse.StatusCode
-	}
+	responseHeader := sleet.GetHTTPResponseHeader(request.Options, *httpResponse)
 	if orbitalResponse.Body.ProcStatus != ProcStatusSuccess {
 		if orbitalResponse.Body.RespCode != "" {
-			return &sleet.AuthorizationResponse{ErrorCode: orbitalResponse.Body.RespCode, StatusCode: statusCode}, nil
+			return &sleet.AuthorizationResponse{
+				ErrorCode:      orbitalResponse.Body.RespCode,
+				StatusCode:     httpResponse.StatusCode,
+				ResponseHeader: responseHeader,
+			}, nil
 		}
 
-		return &sleet.AuthorizationResponse{ErrorCode: RespCodeNotPresent, StatusCode: statusCode}, nil
+		return &sleet.AuthorizationResponse{
+			ErrorCode:      RespCodeNotPresent,
+			StatusCode:     httpResponse.StatusCode,
+			ResponseHeader: responseHeader,
+		}, nil
 	}
 
 	if orbitalResponse.Body.RespCode != RespCodeApproved {
-		return &sleet.AuthorizationResponse{ErrorCode: orbitalResponse.Body.RespCode, StatusCode: statusCode}, nil
+		return &sleet.AuthorizationResponse{
+			ErrorCode:      orbitalResponse.Body.RespCode,
+			StatusCode:     httpResponse.StatusCode,
+			ResponseHeader: responseHeader,
+		}, nil
 	}
 
 	return &sleet.AuthorizationResponse{
@@ -67,7 +76,8 @@ func (client *OrbitalClient) Authorize(request *sleet.AuthorizationRequest) (*sl
 		Response:             strconv.Itoa(int(orbitalResponse.Body.ApprovalStatus)),
 		AvsResultRaw:         string(orbitalResponse.Body.AVSRespCode),
 		CvvResultRaw:         string(orbitalResponse.Body.CVV2RespCode),
-		StatusCode:           statusCode,
+		StatusCode:           httpResponse.StatusCode,
+		ResponseHeader:       responseHeader,
 	}, nil
 }
 

--- a/gateways/orbital/orbital.go
+++ b/gateways/orbital/orbital.go
@@ -47,24 +47,24 @@ func (client *OrbitalClient) Authorize(request *sleet.AuthorizationRequest) (*sl
 	if orbitalResponse.Body.ProcStatus != ProcStatusSuccess {
 		if orbitalResponse.Body.RespCode != "" {
 			return &sleet.AuthorizationResponse{
-				ErrorCode:      orbitalResponse.Body.RespCode,
-				StatusCode:     httpResponse.StatusCode,
-				ResponseHeader: responseHeader,
+				ErrorCode:  orbitalResponse.Body.RespCode,
+				StatusCode: httpResponse.StatusCode,
+				Header:     responseHeader,
 			}, nil
 		}
 
 		return &sleet.AuthorizationResponse{
-			ErrorCode:      RespCodeNotPresent,
-			StatusCode:     httpResponse.StatusCode,
-			ResponseHeader: responseHeader,
+			ErrorCode:  RespCodeNotPresent,
+			StatusCode: httpResponse.StatusCode,
+			Header:     responseHeader,
 		}, nil
 	}
 
 	if orbitalResponse.Body.RespCode != RespCodeApproved {
 		return &sleet.AuthorizationResponse{
-			ErrorCode:      orbitalResponse.Body.RespCode,
-			StatusCode:     httpResponse.StatusCode,
-			ResponseHeader: responseHeader,
+			ErrorCode:  orbitalResponse.Body.RespCode,
+			StatusCode: httpResponse.StatusCode,
+			Header:     responseHeader,
 		}, nil
 	}
 
@@ -77,7 +77,7 @@ func (client *OrbitalClient) Authorize(request *sleet.AuthorizationRequest) (*sl
 		AvsResultRaw:         string(orbitalResponse.Body.AVSRespCode),
 		CvvResultRaw:         string(orbitalResponse.Body.CVV2RespCode),
 		StatusCode:           httpResponse.StatusCode,
-		ResponseHeader:       responseHeader,
+		Header:               responseHeader,
 	}, nil
 }
 

--- a/gateways/orbital/orbital.go
+++ b/gateways/orbital/orbital.go
@@ -49,14 +49,14 @@ func (client *OrbitalClient) Authorize(request *sleet.AuthorizationRequest) (*sl
 	}
 	if orbitalResponse.Body.ProcStatus != ProcStatusSuccess {
 		if orbitalResponse.Body.RespCode != "" {
-			return &sleet.AuthorizationResponse{ErrorCode: orbitalResponse.Body.RespCode, StatusCodeRaw: statusCode}, nil
+			return &sleet.AuthorizationResponse{ErrorCode: orbitalResponse.Body.RespCode, StatusCode: statusCode}, nil
 		}
 
-		return &sleet.AuthorizationResponse{ErrorCode: RespCodeNotPresent, StatusCodeRaw: statusCode}, nil
+		return &sleet.AuthorizationResponse{ErrorCode: RespCodeNotPresent, StatusCode: statusCode}, nil
 	}
 
 	if orbitalResponse.Body.RespCode != RespCodeApproved {
-		return &sleet.AuthorizationResponse{ErrorCode: orbitalResponse.Body.RespCode, StatusCodeRaw: statusCode}, nil
+		return &sleet.AuthorizationResponse{ErrorCode: orbitalResponse.Body.RespCode, StatusCode: statusCode}, nil
 	}
 
 	return &sleet.AuthorizationResponse{
@@ -67,7 +67,7 @@ func (client *OrbitalClient) Authorize(request *sleet.AuthorizationRequest) (*sl
 		Response:             strconv.Itoa(int(orbitalResponse.Body.ApprovalStatus)),
 		AvsResultRaw:         string(orbitalResponse.Body.AVSRespCode),
 		CvvResultRaw:         string(orbitalResponse.Body.CVV2RespCode),
-		StatusCodeRaw:        statusCode,
+		StatusCode:           statusCode,
 	}, nil
 }
 

--- a/gateways/orbital/orbital_test.go
+++ b/gateways/orbital/orbital_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package orbital
@@ -98,7 +99,7 @@ func TestSend(t *testing.T) {
 		var want *Response = new(Response)
 		helper.XmlUnmarshal(responseRaw, want)
 
-		got, err := client.sendRequest(request)
+		got, _, err := client.sendRequest(request)
 
 		if err != nil {
 			t.Fatalf("Error thrown after sending request %q", err)
@@ -176,6 +177,7 @@ func TestAuthorize(t *testing.T) {
 			AvsResultRaw:         string(AVSResponseMatch),
 			CvvResultRaw:         string(CVVResponseMatched),
 			Response:             strconv.Itoa(int(ApprovalStatusApproved)),
+			StatusCode:           200,
 		}
 
 		client := NewClient(common.Sandbox, Credentials{"username", "password", 1})

--- a/gateways/paypalpayflow/paypalpayflow.go
+++ b/gateways/paypalpayflow/paypalpayflow.go
@@ -117,14 +117,14 @@ func (client *PaypalPayflowClient) Authorize(request *sleet.AuthorizationRequest
 			Success:              true,
 			TransactionReference: transactionID,
 			StatusCode:           httpResponse.StatusCode,
-			ResponseHeader:       responseHeader,
+			Header:               responseHeader,
 		}, nil
 	}
 
 	return &sleet.AuthorizationResponse{
-		ErrorCode:      result,
-		StatusCode:     httpResponse.StatusCode,
-		ResponseHeader: responseHeader,
+		ErrorCode:  result,
+		StatusCode: httpResponse.StatusCode,
+		Header:     responseHeader,
 	}, nil
 }
 

--- a/gateways/paypalpayflow/paypalpayflow.go
+++ b/gateways/paypalpayflow/paypalpayflow.go
@@ -119,13 +119,13 @@ func (client *PaypalPayflowClient) Authorize(request *sleet.AuthorizationRequest
 		return &sleet.AuthorizationResponse{
 			Success:              true,
 			TransactionReference: transactionID,
-			StatusCodeRaw:        statusCode,
+			StatusCode:           statusCode,
 		}, nil
 	}
 
 	return &sleet.AuthorizationResponse{
-		ErrorCode:     result,
-		StatusCodeRaw: statusCode,
+		ErrorCode:  result,
+		StatusCode: statusCode,
 	}, nil
 }
 

--- a/gateways/paypalpayflow/paypalpayflow.go
+++ b/gateways/paypalpayflow/paypalpayflow.go
@@ -109,23 +109,22 @@ func (client *PaypalPayflowClient) Authorize(request *sleet.AuthorizationRequest
 		return nil, err
 	}
 
-	var statusCode int
-	if !sleet.IsTokenizerProxyError(httpResponse.Header) {
-		statusCode = httpResponse.StatusCode
-	}
+	responseHeader := sleet.GetHTTPResponseHeader(request.Options, *httpResponse)
 	transactionID, ok1 := (*response)[transactionFieldName]
 	result, ok2 := (*response)[resultFieldName]
 	if ok1 && ok2 && result == successResponse {
 		return &sleet.AuthorizationResponse{
 			Success:              true,
 			TransactionReference: transactionID,
-			StatusCode:           statusCode,
+			StatusCode:           httpResponse.StatusCode,
+			ResponseHeader:       responseHeader,
 		}, nil
 	}
 
 	return &sleet.AuthorizationResponse{
-		ErrorCode:  result,
-		StatusCode: statusCode,
+		ErrorCode:      result,
+		StatusCode:     httpResponse.StatusCode,
+		ResponseHeader: responseHeader,
 	}, nil
 }
 

--- a/testing/auth_request.go
+++ b/testing/auth_request.go
@@ -39,6 +39,14 @@ func BaseAuthorizationRequestWithEmailPhoneNumber() *sleet.AuthorizationRequest 
 	return base
 }
 
+func BaseAuthorizationRequestWithResponseHeaderOption() *sleet.AuthorizationRequest {
+	base := BaseAuthorizationRequest()
+	base.Options = map[string]interface{}{
+		sleet.ResponseHeaderOption: []string{"x-test-header"},
+	}
+	return base
+}
+
 // BaseLevel3Data is used as a testing helper method to standardize request calls for integration tests
 func BaseLevel3Data() *sleet.Level3Data {
 	return &sleet.Level3Data{

--- a/types.go
+++ b/types.go
@@ -122,7 +122,7 @@ type AuthorizationResponse struct {
 	RTAUResult            *RTAUResponse
 	AdyenAdditionalData   map[string]string // store additional recurring info (will be refactored to general naming on next major version upgrade)
 	StatusCode            int               // the status code from raw PSP http response.
-	ResponseHeader        http.Header       // the http response header
+	Header                http.Header       // the http response header
 }
 
 // CaptureRequest specifies the authorized transaction to capture and also an amount for partial capture use cases

--- a/types.go
+++ b/types.go
@@ -114,7 +114,7 @@ type AuthorizationResponse struct {
 	CvvResultRaw          string
 	RTAUResult            *RTAUResponse
 	AdyenAdditionalData   map[string]string // store additional recurring info (will be refactored to general naming on next major version upgrade)
-	StatusCode            int               // the http response status code.
+	StatusCodeRaw         int               // the status code from raw PSP http response.
 }
 
 // CaptureRequest specifies the authorized transaction to capture and also an amount for partial capture use cases

--- a/types.go
+++ b/types.go
@@ -175,8 +175,8 @@ type RefundResponse struct {
 // GetHTTPResponseHeader returns the http response headers specified in the given options.
 func GetHTTPResponseHeader(options map[string]interface{}, httpResp http.Response) http.Header {
 	var responseHeader http.Header
-	if options[ResponseHeaderOption] != nil {
-		for _, header := range options[ResponseHeaderOption].([]string) {
+	if headers, ok := options[ResponseHeaderOption].([]string); ok {
+		for _, header := range headers {
 			responseHeader.Add(header, httpResp.Header.Get(header))
 		}
 	}

--- a/types.go
+++ b/types.go
@@ -114,7 +114,7 @@ type AuthorizationResponse struct {
 	CvvResultRaw          string
 	RTAUResult            *RTAUResponse
 	AdyenAdditionalData   map[string]string // store additional recurring info (will be refactored to general naming on next major version upgrade)
-	StatusCodeRaw         int               // the status code from raw PSP http response.
+	StatusCode            int               // the status code from raw PSP http response.
 }
 
 // CaptureRequest specifies the authorized transaction to capture and also an amount for partial capture use cases

--- a/types.go
+++ b/types.go
@@ -114,6 +114,7 @@ type AuthorizationResponse struct {
 	CvvResultRaw          string
 	RTAUResult            *RTAUResponse
 	AdyenAdditionalData   map[string]string // store additional recurring info (will be refactored to general naming on next major version upgrade)
+	StatusCode            int               // the http response status code.
 }
 
 // CaptureRequest specifies the authorized transaction to capture and also an amount for partial capture use cases

--- a/types.go
+++ b/types.go
@@ -1,6 +1,9 @@
 package sleet
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 // Client defines the Sleet interface which takes in a generic request and returns a generic response
 // The translations for each specific PsP takes place in the corresponding gateways/<PsP> folders
@@ -73,6 +76,10 @@ type Level3Data struct {
 	LineItems              []LineItem
 }
 
+const (
+	ResponseHeaderOption string = "ResponseHeader"
+)
+
 // AuthorizationRequest specifies needed information for request to authorize by PsPs
 // Note: Only credit cards are supported
 // Note: Options is a generic key-value pair that can be used to provide additional information to PsP
@@ -115,6 +122,7 @@ type AuthorizationResponse struct {
 	RTAUResult            *RTAUResponse
 	AdyenAdditionalData   map[string]string // store additional recurring info (will be refactored to general naming on next major version upgrade)
 	StatusCode            int               // the status code from raw PSP http response.
+	ResponseHeader        http.Header       // the http response header
 }
 
 // CaptureRequest specifies the authorized transaction to capture and also an amount for partial capture use cases
@@ -162,6 +170,17 @@ type RefundResponse struct {
 	Success              bool
 	TransactionReference string
 	ErrorCode            *string
+}
+
+// GetHTTPResponseHeader returns the http response headers specified in the given options.
+func GetHTTPResponseHeader(options map[string]interface{}, httpResp http.Response) http.Header {
+	var responseHeader http.Header
+	if options[ResponseHeaderOption] != nil {
+		for _, header := range options[ResponseHeaderOption].([]string) {
+			responseHeader.Add(header, httpResp.Header.Get(header))
+		}
+	}
+	return responseHeader
 }
 
 // Currency maps to the CURRENCIES list in currency.go specifying the symbol and precision for the currency

--- a/types.go
+++ b/types.go
@@ -176,8 +176,11 @@ type RefundResponse struct {
 func GetHTTPResponseHeader(options map[string]interface{}, httpResp http.Response) http.Header {
 	var responseHeader http.Header
 	if headers, ok := options[ResponseHeaderOption].([]string); ok {
+		responseHeader = make(http.Header)
 		for _, header := range headers {
-			responseHeader.Add(header, httpResp.Header.Get(header))
+			if headerValue := httpResp.Header.Get(header); len(headerValue) > 0 {
+				responseHeader.Add(header, headerValue)
+			}
 		}
 	}
 	return responseHeader

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,13 @@
 package sleet
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
+
+const (
+	HeaderXProxyError = "X-Proxy-Error"
+)
 
 // AmountToString converts an integer amount to a string with no formatting
 func AmountToString(amount *Amount) string {
@@ -28,4 +35,11 @@ func DefaultIfEmpty(primary string, fallback string) string {
 		return fallback
 	}
 	return primary
+}
+
+// IsTokenizerProxyError checks if the error comes from the Tokenizer.
+// It relies on the X-Proxy-Error header which will be set when it's TK internal error:
+// https://github.com/BoltApp/tokenization/blob/master/bolt/tk/app/handlers.ts#L24
+func IsTokenizerProxyError(header http.Header) bool {
+	return len(header.Get(HeaderXProxyError)) > 0
 }

--- a/utils.go
+++ b/utils.go
@@ -1,13 +1,6 @@
 package sleet
 
-import (
-	"fmt"
-	"net/http"
-)
-
-const (
-	HeaderXProxyError = "X-Proxy-Error"
-)
+import "fmt"
 
 // AmountToString converts an integer amount to a string with no formatting
 func AmountToString(amount *Amount) string {
@@ -35,11 +28,4 @@ func DefaultIfEmpty(primary string, fallback string) string {
 		return fallback
 	}
 	return primary
-}
-
-// IsTokenizerProxyError checks if the error comes from the Tokenizer.
-// It relies on the X-Proxy-Error header which will be set when it's TK internal error:
-// https://github.com/BoltApp/tokenization/blob/master/bolt/tk/app/handlers.ts#L24
-func IsTokenizerProxyError(header http.Header) bool {
-	return len(header.Get(HeaderXProxyError)) > 0
 }


### PR DESCRIPTION
Description: this PR adds the http status code and response headers to the `sleet.AuthorizationResponse` struct, they will be passed back to the backend service to identify PSP internal issues.