### PR TITLE
Add currency to paypal payflow request

### DIFF
--- a/gateways/paypalpayflow/paypalpayflow.go
+++ b/gateways/paypalpayflow/paypalpayflow.go
@@ -42,6 +42,7 @@ func (client *PaypalPayflowClient) sendRequest(request *Request) (*Response, *ht
 		"USER":            client.user,
 		"TRXTYPE":         request.TrxType,
 		"AMT":             request.Amount,
+		"CURRENCY":        request.Currency,
 		"VERBOSITY":       request.Verbosity,
 		"TENDER":          request.Tender,
 		"ACCT":            request.CreditCardNumber,

--- a/gateways/paypalpayflow/request_builder.go
+++ b/gateways/paypalpayflow/request_builder.go
@@ -65,6 +65,7 @@ func buildCaptureParams(request *sleet.CaptureRequest) *Request {
 		Verbosity:  &defaultVerbosity,
 		Tender:     &defaultTender,
 		Amount:     &amount,
+		Currency:   &request.Amount.Currency,
 	}
 }
 
@@ -78,10 +79,14 @@ func buildVoidParams(request *sleet.VoidRequest) *Request {
 }
 
 func buildRefundParams(request *sleet.RefundRequest) *Request {
-	var amount *string = nil
+	var (
+		amount   *string
+		currency *string
+	)
 	if request.Amount != nil {
 		res := sleet.AmountToDecimalString(request.Amount)
 		amount = &res
+		currency = &request.Amount.Currency
 	}
 	return &Request{
 		TrxType:    REFUND,
@@ -89,5 +94,6 @@ func buildRefundParams(request *sleet.RefundRequest) *Request {
 		Verbosity:  &defaultVerbosity,
 		Tender:     &defaultTender,
 		Amount:     amount,
+		Currency:   currency,
 	}
 }

--- a/gateways/paypalpayflow/request_builder.go
+++ b/gateways/paypalpayflow/request_builder.go
@@ -40,6 +40,7 @@ func buildAuthorizeParams(request *sleet.AuthorizationRequest) *Request {
 	return &Request{
 		TrxType:            AUTHORIZATION,
 		Amount:             &amount,
+		Currency:           &request.Amount.Currency,
 		CreditCardNumber:   &request.CreditCard.Number,
 		CardExpirationDate: &expirationDate,
 		Verbosity:          &defaultVerbosity,

--- a/gateways/paypalpayflow/request_builders_test.go
+++ b/gateways/paypalpayflow/request_builders_test.go
@@ -13,6 +13,7 @@ var (
 	defaultTestVerbosity      string = "HIGH"
 	defaultTestTender         string = "C"
 	defaultTestAmount         string = "1.00"
+	defaultTestCurrency       string = "USD"
 	defaultTestExpirationDate string = "1023"
 	OriginalID                string = "111111"
 )
@@ -44,6 +45,7 @@ func TestBuildAuthRequest(t *testing.T) {
 			Request{
 				TrxType:            AUTHORIZATION,
 				Amount:             &defaultTestAmount,
+				Currency:           &defaultTestCurrency,
 				CreditCardNumber:   &visaBase.CreditCard.Number,
 				CardExpirationDate: &defaultTestExpirationDate,
 				Verbosity:          &defaultTestVerbosity,
@@ -63,6 +65,7 @@ func TestBuildAuthRequest(t *testing.T) {
 			Request{
 				TrxType:            AUTHORIZATION,
 				Amount:             &defaultTestAmount,
+				Currency:           &defaultTestCurrency,
 				CreditCardNumber:   &discoverBase.CreditCard.Number,
 				CardExpirationDate: &defaultTestExpirationDate,
 				Verbosity:          &defaultTestVerbosity,
@@ -82,6 +85,7 @@ func TestBuildAuthRequest(t *testing.T) {
 			Request{
 				TrxType:            AUTHORIZATION,
 				Amount:             &defaultTestAmount,
+				Currency:           &defaultTestCurrency,
 				CreditCardNumber:   &mastercardBase.CreditCard.Number,
 				CardExpirationDate: &defaultTestExpirationDate,
 				Verbosity:          &defaultTestVerbosity,
@@ -101,6 +105,7 @@ func TestBuildAuthRequest(t *testing.T) {
 			Request{
 				TrxType:            AUTHORIZATION,
 				Amount:             &defaultTestAmount,
+				Currency:           &defaultTestCurrency,
 				CreditCardNumber:   &applepayBase.CreditCard.Number,
 				CardExpirationDate: &defaultTestExpirationDate,
 				Verbosity:          &defaultTestVerbosity,

--- a/gateways/paypalpayflow/request_builders_test.go
+++ b/gateways/paypalpayflow/request_builders_test.go
@@ -147,6 +147,7 @@ func TestBuildCaptureRequest(t *testing.T) {
 				Verbosity:  &defaultTestVerbosity,
 				Tender:     &defaultTestTender,
 				Amount:     &defaultTestAmount,
+				Currency:   &defaultTestCurrency,
 			},
 		},
 	}
@@ -208,6 +209,7 @@ func TestBuildRefundRequest(t *testing.T) {
 				Verbosity:  &defaultTestVerbosity,
 				Tender:     &defaultTestTender,
 				Amount:     &defaultTestAmount,
+				Currency:   &defaultTestCurrency,
 			},
 		},
 	}

--- a/gateways/paypalpayflow/types.go
+++ b/gateways/paypalpayflow/types.go
@@ -27,6 +27,7 @@ const (
 type Request struct {
 	TrxType            string
 	Amount             *string
+	Currency           *string
 	Verbosity          *string
 	Tender             *string
 	CreditCardNumber   *string

--- a/integration-tests/paypalpayflow_test.go
+++ b/integration-tests/paypalpayflow_test.go
@@ -31,6 +31,25 @@ func TestPaypalAuth(t *testing.T) {
 	}
 }
 
+func TestPaypalAuthWithCurrency(t *testing.T) {
+	client := paypalpayflow.NewClient(getEnv("PAYPAL_PARTNER"), getEnv("PAYPAL_PASSWORD"), getEnv("PAYPAL_VENDOR"), getEnv("PAYPAL_USER"), common.Sandbox)
+	authRequest := sleet_testing.BaseAuthorizationRequestWithEmailPhoneNumber()
+	authRequest.Amount.Amount = int64(randomdata.Number(10000))
+	authRequest.Amount.Currency = "CAD"
+	authRequest.MerchantOrderReference = "test-order-ref"
+	authRequest.CreditCard.ExpirationMonth = 3
+	authRequest.CreditCard.ExpirationYear = 25
+	authRequest.CreditCard.Number = "4222222222222"
+	auth, err := client.Authorize(authRequest)
+	if err != nil {
+		t.Error("Authorize request should not have failed")
+	}
+
+	if !auth.Success {
+		t.Error("Resulting auth should have been successful")
+	}
+}
+
 func TestPaypalAuthBadCredentials(t *testing.T) {
 	client := paypalpayflow.NewClient("PAYPAL_PARTNER", "PAYPAL_PASSWORD", getEnv("PAYPAL_VENDOR"), getEnv("PAYPAL_USER"), common.Sandbox)
 	authRequest := sleet_testing.BaseAuthorizationRequestWithEmailPhoneNumber()

--- a/integration-tests/paypalpayflow_test.go
+++ b/integration-tests/paypalpayflow_test.go
@@ -31,25 +31,6 @@ func TestPaypalAuth(t *testing.T) {
 	}
 }
 
-func TestPaypalAuthWithCurrency(t *testing.T) {
-	client := paypalpayflow.NewClient(getEnv("PAYPAL_PARTNER"), getEnv("PAYPAL_PASSWORD"), getEnv("PAYPAL_VENDOR"), getEnv("PAYPAL_USER"), common.Sandbox)
-	authRequest := sleet_testing.BaseAuthorizationRequestWithEmailPhoneNumber()
-	authRequest.Amount.Amount = int64(randomdata.Number(10000))
-	authRequest.Amount.Currency = "CAD"
-	authRequest.MerchantOrderReference = "test-order-ref"
-	authRequest.CreditCard.ExpirationMonth = 3
-	authRequest.CreditCard.ExpirationYear = 25
-	authRequest.CreditCard.Number = "4222222222222"
-	auth, err := client.Authorize(authRequest)
-	if err != nil {
-		t.Error("Authorize request should not have failed")
-	}
-
-	if !auth.Success {
-		t.Error("Resulting auth should have been successful")
-	}
-}
-
 func TestPaypalAuthBadCredentials(t *testing.T) {
 	client := paypalpayflow.NewClient("PAYPAL_PARTNER", "PAYPAL_PASSWORD", getEnv("PAYPAL_VENDOR"), getEnv("PAYPAL_USER"), common.Sandbox)
 	authRequest := sleet_testing.BaseAuthorizationRequestWithEmailPhoneNumber()
@@ -140,6 +121,54 @@ func TestPaypalAuthCaptureRefund(t *testing.T) {
 	client := paypalpayflow.NewClient(getEnv("PAYPAL_PARTNER"), getEnv("PAYPAL_PASSWORD"), getEnv("PAYPAL_VENDOR"), getEnv("PAYPAL_USER"), common.Sandbox)
 	authRequest := sleet_testing.BaseAuthorizationRequestWithEmailPhoneNumber()
 	authRequest.Amount.Amount = int64(randomdata.Number(100) * 100)
+	authRequest.MerchantOrderReference = transactionID
+	authRequest.CreditCard.ExpirationMonth = 3
+	authRequest.CreditCard.ExpirationYear = 25
+	authRequest.CreditCard.Number = "4012888888881881"
+	auth, err := client.Authorize(authRequest)
+	if err != nil {
+		t.Error("Authorize request should not have failed")
+	}
+
+	if !auth.Success {
+		t.Error("Resulting auth should have been successful")
+	}
+
+	captureRequest := &sleet.CaptureRequest{
+		Amount:               &authRequest.Amount,
+		TransactionReference: auth.TransactionReference,
+	}
+
+	capture, err := client.Capture(captureRequest)
+	if err != nil {
+		t.Error("Capture request should not have failed")
+	}
+
+	if !capture.Success {
+		t.Error("Resulting capture should have been successful")
+	}
+
+	refundRequest := &sleet.RefundRequest{
+		Amount:               &authRequest.Amount,
+		Last4:                authRequest.CreditCard.Number,
+		TransactionReference: capture.TransactionReference,
+	}
+
+	refund, err := client.Refund(refundRequest)
+	if err != nil {
+		t.Error("Refund request should not have failed")
+	}
+	if !refund.Success {
+		t.Error("Resulting refund should have been successful")
+	}
+}
+
+func TestPaypalAuthCaptureRefundWithNonUSDCurrency(t *testing.T) {
+	transactionID := "test-order-refund"
+	client := paypalpayflow.NewClient(getEnv("PAYPAL_PARTNER"), getEnv("PAYPAL_PASSWORD"), getEnv("PAYPAL_VENDOR"), getEnv("PAYPAL_USER"), common.Sandbox)
+	authRequest := sleet_testing.BaseAuthorizationRequestWithEmailPhoneNumber()
+	authRequest.Amount.Amount = int64(randomdata.Number(100) * 100)
+	authRequest.Amount.Currency = "CAD"
 	authRequest.MerchantOrderReference = transactionID
 	authRequest.CreditCard.ExpirationMonth = 3
 	authRequest.CreditCard.ExpirationYear = 25


### PR DESCRIPTION
Description: we had an [issue](https://app.asana.com/0/1201437212753355/1202461617728612) where the currency was not correctly shown in paypal, turned out we didn't pass the currency to the request params, this PR is to fix it.

Reference: https://developer.paypal.com/api/nvp-soap/payflow/integration-guide/additional-parameters/#paypal-credit-card-transaction-request-parameters

TestPlan: unit tests + integration tests