### PR TITLE
add customer ip to authnet options

### DIFF
--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -27,7 +27,8 @@ func TestBuildAuthRequest(t *testing.T) {
 	baseL2L3MultipleItems.Level3Data = sleet_testing.BaseLevel3DataMultipleItem()
 	baseL2L3MultipleItems.ShippingAddress = baseL2L3MultipleItems.BillingAddress
 
-	withCustomerIP := sleet_testing.BaseAuthorizationRequest()
+	withCustomerIP := sleet_testing.BaseAuthorizationRequestWithEmailPhoneNumber()
+	withCustomerIP.MerchantOrderReference = randomdata.Alphanumeric(InvoiceNumberMaxLength + 5)
 	customerIP := common.SPtr("192.168.0.1")
 	if withCustomerIP.Options == nil {
 		withCustomerIP.Options = make(map[string]interface{})
@@ -239,24 +240,24 @@ func TestBuildAuthRequest(t *testing.T) {
 							CreditCard: CreditCard{
 								CardNumber:     "4111111111111111",
 								ExpirationDate: "2023-10",
-								CardCode:       base.CreditCard.CVV,
+								CardCode:       withCustomerIP.CreditCard.CVV,
 							},
 						},
 						BillingAddress: &BillingAddress{
 							FirstName:   "Bolt",
 							LastName:    "Checkout",
-							Address:     base.BillingAddress.StreetAddress1,
-							City:        base.BillingAddress.Locality,
-							State:       base.BillingAddress.RegionCode,
-							Zip:         base.BillingAddress.PostalCode,
-							Country:     base.BillingAddress.CountryCode,
-							PhoneNumber: base.BillingAddress.PhoneNumber,
+							Address:     withCustomerIP.BillingAddress.StreetAddress1,
+							City:        withCustomerIP.BillingAddress.Locality,
+							State:       withCustomerIP.BillingAddress.RegionCode,
+							Zip:         withCustomerIP.BillingAddress.PostalCode,
+							Country:     withCustomerIP.BillingAddress.CountryCode,
+							PhoneNumber: withCustomerIP.BillingAddress.PhoneNumber,
 						},
 						Order: &Order{
-							InvoiceNumber: base.MerchantOrderReference[:InvoiceNumberMaxLength],
+							InvoiceNumber: withCustomerIP.MerchantOrderReference[:InvoiceNumberMaxLength],
 						},
 						Customer: &Customer{
-							Email: *base.BillingAddress.Email,
+							Email: *withCustomerIP.BillingAddress.Email,
 						},
 						CustomerIP: customerIP,
 					},

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package authorizenet
@@ -26,6 +27,10 @@ func TestBuildAuthRequest(t *testing.T) {
 	baseL2L3MultipleItems.Level3Data = sleet_testing.BaseLevel3DataMultipleItem()
 	baseL2L3MultipleItems.ShippingAddress = baseL2L3MultipleItems.BillingAddress
 
+	withCustomerIP := sleet_testing.BaseAuthorizationRequest()
+	customerIP := common.SPtr("192.168.0.1")
+	withCustomerIP.Options[customerIPOption] = customerIP
+
 	amount := "1.00"
 	cases := []struct {
 		label string
@@ -49,13 +54,13 @@ func TestBuildAuthRequest(t *testing.T) {
 							},
 						},
 						BillingAddress: &BillingAddress{
-							FirstName: "Bolt",
-							LastName:  "Checkout",
-							Address:   base.BillingAddress.StreetAddress1,
-							City:      base.BillingAddress.Locality,
-							State:     base.BillingAddress.RegionCode,
-							Zip:       base.BillingAddress.PostalCode,
-							Country:   base.BillingAddress.CountryCode,
+							FirstName:   "Bolt",
+							LastName:    "Checkout",
+							Address:     base.BillingAddress.StreetAddress1,
+							City:        base.BillingAddress.Locality,
+							State:       base.BillingAddress.RegionCode,
+							Zip:         base.BillingAddress.PostalCode,
+							Country:     base.BillingAddress.CountryCode,
 							PhoneNumber: base.BillingAddress.PhoneNumber,
 						},
 						Order: &Order{
@@ -92,13 +97,13 @@ func TestBuildAuthRequest(t *testing.T) {
 							},
 						},
 						BillingAddress: &BillingAddress{
-							FirstName: "Bolt",
-							LastName:  "Checkout",
-							Address:   base.BillingAddress.StreetAddress1,
-							City:      base.BillingAddress.Locality,
-							State:     base.BillingAddress.RegionCode,
-							Zip:       base.BillingAddress.PostalCode,
-							Country:   base.BillingAddress.CountryCode,
+							FirstName:   "Bolt",
+							LastName:    "Checkout",
+							Address:     base.BillingAddress.StreetAddress1,
+							City:        base.BillingAddress.Locality,
+							State:       base.BillingAddress.RegionCode,
+							Zip:         base.BillingAddress.PostalCode,
+							Country:     base.BillingAddress.CountryCode,
 							PhoneNumber: base.BillingAddress.PhoneNumber,
 						},
 						Customer: &Customer{
@@ -214,6 +219,43 @@ func TestBuildAuthRequest(t *testing.T) {
 							Zip:       base.BillingAddress.PostalCode,
 							Country:   base.BillingAddress.CountryCode,
 						},
+					},
+				},
+			},
+		},
+		{
+			"Basic Auth Request with customer IP",
+			withCustomerIP,
+			&Request{
+				CreateTransactionRequest: CreateTransactionRequest{
+					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
+					TransactionRequest: TransactionRequest{
+						TransactionType: TransactionTypeAuthOnly,
+						Amount:          &amount,
+						Payment: &Payment{
+							CreditCard: CreditCard{
+								CardNumber:     "4111111111111111",
+								ExpirationDate: "2023-10",
+								CardCode:       base.CreditCard.CVV,
+							},
+						},
+						BillingAddress: &BillingAddress{
+							FirstName:   "Bolt",
+							LastName:    "Checkout",
+							Address:     base.BillingAddress.StreetAddress1,
+							City:        base.BillingAddress.Locality,
+							State:       base.BillingAddress.RegionCode,
+							Zip:         base.BillingAddress.PostalCode,
+							Country:     base.BillingAddress.CountryCode,
+							PhoneNumber: base.BillingAddress.PhoneNumber,
+						},
+						Order: &Order{
+							InvoiceNumber: base.MerchantOrderReference[:InvoiceNumberMaxLength],
+						},
+						Customer: &Customer{
+							Email: *base.BillingAddress.Email,
+						},
+						CustomerIP: customerIP,
 					},
 				},
 			},

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -29,6 +29,9 @@ func TestBuildAuthRequest(t *testing.T) {
 
 	withCustomerIP := sleet_testing.BaseAuthorizationRequest()
 	customerIP := common.SPtr("192.168.0.1")
+	if withCustomerIP.Options == nil {
+		withCustomerIP.Options = make(map[string]interface{})
+	}
 	withCustomerIP.Options[customerIPOption] = customerIP
 
 	amount := "1.00"

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -113,19 +113,20 @@ type MerchantAuthentication struct {
 // *************************************************************************
 // *************************************************************************
 type TransactionRequest struct {
-	TransactionType  TransactionType  `json:"transactionType"`
-	Amount           *string          `json:"amount,omitempty"`
-	Payment          *Payment         `json:"payment,omitempty"`
-	RefTransactionID *string          `json:"refTransId,omitempty"`
-	Order            *Order           `json:"order,omitempty"`
-	LineItem         json.RawMessage  `json:"lineItems,omitempty"` // this is really a repeating LineItem, but authorize.net expects it in object not array
+	TransactionType  TransactionType `json:"transactionType"`
+	Amount           *string         `json:"amount,omitempty"`
+	Payment          *Payment        `json:"payment,omitempty"`
+	RefTransactionID *string         `json:"refTransId,omitempty"`
+	Order            *Order          `json:"order,omitempty"`
+	LineItem         json.RawMessage `json:"lineItems,omitempty"` // this is really a repeating LineItem, but authorize.net expects it in object not array
 	// since not valid json, just going to represent as JSON string
-	Tax              *Tax             `json:"tax,omitempty"`
-	Duty             *Tax             `json:"duty,omitempty"`
-	Shipping         *Tax             `json:"shipping,omitempty"`
-	Customer         *Customer        `json:"customer,omitempty"`
-	BillingAddress   *BillingAddress  `json:"billTo,omitempty"`
-	ShippingAddress  *ShippingAddress `json:"shipTo,omitempty"`
+	Tax             *Tax             `json:"tax,omitempty"`
+	Duty            *Tax             `json:"duty,omitempty"`
+	Shipping        *Tax             `json:"shipping,omitempty"`
+	Customer        *Customer        `json:"customer,omitempty"`
+	BillingAddress  *BillingAddress  `json:"billTo,omitempty"`
+	ShippingAddress *ShippingAddress `json:"shipTo,omitempty"`
+	CustomerIP      *string          `json:"customerIP,omitempty"`
 }
 
 type LineItem struct {
@@ -176,14 +177,14 @@ type ShippingAddress struct {
 
 // BillingAddress is used in TransactionRequest for making an auth call
 type BillingAddress struct {
-	FirstName string  `json:"firstName"`
-	LastName  string  `json:"lastName"`
-	Company   string  `json:"company"`
-	Address   *string `json:"address"`
-	City      *string `json:"city"`
-	State     *string `json:"state"`
-	Zip       *string `json:"zip"`
-	Country   *string `json:"country"`
+	FirstName   string  `json:"firstName"`
+	LastName    string  `json:"lastName"`
+	Company     string  `json:"company"`
+	Address     *string `json:"address"`
+	City        *string `json:"city"`
+	State       *string `json:"state"`
+	Zip         *string `json:"zip"`
+	Country     *string `json:"country"`
 	PhoneNumber *string `json:"phoneNumber"`
 }
 

--- a/integration-tests/authorizenet_test.go
+++ b/integration-tests/authorizenet_test.go
@@ -67,6 +67,9 @@ func TestAuthNetAuthL2L3MultipleItem(t *testing.T) {
 func TestAuthNetAuthWithCustomerIP(t *testing.T) {
 	client := authorizenet.NewClient(getEnv("AUTH_NET_LOGIN_ID"), getEnv("AUTH_NET_TXN_KEY"), common.Sandbox)
 	authRequest := sleet_testing.BaseAuthorizationRequestWithEmailPhoneNumber()
+	if authRequest.Options == nil {
+		authRequest.Options = make(map[string]interface{})
+	}
 	authRequest.Options["CustomerIP"] = sPtr("192.168.0.1")
 	authRequest.Amount.Amount = int64(randomdata.Number(100))
 	authRequest.MerchantOrderReference = "test-order-ref"

--- a/integration-tests/authorizenet_test.go
+++ b/integration-tests/authorizenet_test.go
@@ -64,6 +64,22 @@ func TestAuthNetAuthL2L3MultipleItem(t *testing.T) {
 	}
 }
 
+func TestAuthNetAuthWithCustomerIP(t *testing.T) {
+	client := authorizenet.NewClient(getEnv("AUTH_NET_LOGIN_ID"), getEnv("AUTH_NET_TXN_KEY"), common.Sandbox)
+	authRequest := sleet_testing.BaseAuthorizationRequestWithEmailPhoneNumber()
+	authRequest.Options["CustomerIP"] = sPtr("192.168.0.1")
+	authRequest.Amount.Amount = int64(randomdata.Number(100))
+	authRequest.MerchantOrderReference = "test-order-ref"
+	auth, err := client.Authorize(authRequest)
+	if err != nil {
+		t.Error("Authorize request should not have failed")
+	}
+
+	if !auth.Success {
+		t.Error("Resulting auth should have been successful")
+	}
+}
+
 // TestAuthNetRechargeAuth
 //
 // Recharge requests will not have CVV. This should successfully create an authorization on Authorize.net
@@ -203,8 +219,8 @@ func TestAuthNetAuthCaptureRefund(t *testing.T) {
 	// Refunds for AuthNet take 24 hours to settle. The only option for immediate testing is to do a non-transaction
 	// referenced refund. We will send full credit card number
 	refundRequest := &sleet.RefundRequest{
-		Amount:               &authRequest.Amount,
-		Last4: authRequest.CreditCard.Number,
+		Amount:                 &authRequest.Amount,
+		Last4:                  authRequest.CreditCard.Number,
 		MerchantOrderReference: common.SPtr(randomdata.Digits(16)),
 		Options: map[string]interface{}{
 			"TestingExpirationOverride": fmt.Sprintf("%d%d", authRequest.CreditCard.ExpirationMonth, authRequest.CreditCard.ExpirationYear),


### PR DESCRIPTION
Supports customerIP field in the options map for users who are using authnet fraud rules