### PR TITLE
Krebs/AuthNetVoidIfNotSettled

### DIFF
--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -3,7 +3,6 @@ package authorizenet
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -101,15 +100,12 @@ func (client *AuthorizeNetClient) Void(request *sleet.VoidRequest) (*sleet.VoidR
 
 func (client *AuthorizeNetClient) isTransactionSettled(merchantName string, transactionKey string, transactionID string) (bool, error) {
 	authorizeNetGetTransactionDetailsRequest := buildTransactionDetailRequest(merchantName, transactionKey, transactionID)
-	authorizeNetResponse, resp, err := client.sendGetTransactionDetailsRequest(*authorizeNetGetTransactionDetailsRequest)
+	authorizeNetResponse, _, err := client.sendGetTransactionDetailsRequest(*authorizeNetGetTransactionDetailsRequest)
 	if err != nil {
 		return false, err
 	}
 
-	if resp != nil {
-		fmt.Print("test resp")
-	}
-	transactionStatus := authorizeNetResponse.GetTransactionDetailsResponse.Transaction.TransactionStatus
+	transactionStatus := authorizeNetResponse.Transaction.TransactionStatus
 	if transactionStatus != transactionStatusSettledSuccessfully {
 		return false, nil
 	}
@@ -163,13 +159,13 @@ func (client *AuthorizeNetClient) Refund(request *sleet.RefundRequest) (*sleet.R
 	}, nil
 }
 
-func (client *AuthorizeNetClient) sendGetTransactionDetailsRequest(data Request) (*TransactionDetailsResponse, *http.Response, error) {
+func (client *AuthorizeNetClient) sendGetTransactionDetailsRequest(data Request) (*GetTransactionDetailsResponse, *http.Response, error) {
 	bodyBytes, resp, err := client.sendRequestAndReturnBytes(data)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var transactionDetailsResponse TransactionDetailsResponse
+	var transactionDetailsResponse GetTransactionDetailsResponse
 	err = json.Unmarshal(*bodyBytes, &transactionDetailsResponse)
 	if err != nil {
 		return nil, nil, err

--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -74,12 +74,12 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 		}
 	}
 
-	return &Request{CreateTransactionRequest: authorizeRequest}
+	return &Request{CreateTransactionRequest: &authorizeRequest}
 }
 
 func buildVoidRequest(merchantName string, transactionKey string, voidRequest *sleet.VoidRequest) *Request {
 	return &Request{
-		CreateTransactionRequest: CreateTransactionRequest{
+		CreateTransactionRequest: &CreateTransactionRequest{
 			MerchantAuthentication: authentication(merchantName, transactionKey),
 			TransactionRequest: TransactionRequest{
 				TransactionType:  TransactionTypeVoid,
@@ -92,7 +92,7 @@ func buildVoidRequest(merchantName string, transactionKey string, voidRequest *s
 func buildCaptureRequest(merchantName string, transactionKey string, captureRequest *sleet.CaptureRequest) *Request {
 	amountStr := sleet.AmountToDecimalString(captureRequest.Amount)
 	request := &Request{
-		CreateTransactionRequest: CreateTransactionRequest{
+		CreateTransactionRequest: &CreateTransactionRequest{
 			MerchantAuthentication: authentication(merchantName, transactionKey),
 			TransactionRequest: TransactionRequest{
 				TransactionType:  TransactionTypePriorAuthCapture,
@@ -104,13 +104,22 @@ func buildCaptureRequest(merchantName string, transactionKey string, captureRequ
 	return request
 }
 
+func buildTransactionDetailRequest(merchantName string, transactionKey string, transactionID string) *Request {
+	return &Request{
+		GetTransactionDetailsRequest: &GetTransactionDetailsRequest{
+			MerchantAuthentication: authentication(merchantName, transactionKey),
+			TransID:                transactionID,
+		},
+	}
+}
+
 func buildRefundRequest(merchantName string, transactionKey string, refundRequest *sleet.RefundRequest) (
 	*Request,
 	error,
 ) {
 	amountStr := sleet.AmountToDecimalString(refundRequest.Amount)
 	request := &Request{
-		CreateTransactionRequest: CreateTransactionRequest{
+		CreateTransactionRequest: &CreateTransactionRequest{
 			MerchantAuthentication: authentication(merchantName, transactionKey),
 			TransactionRequest: TransactionRequest{
 				TransactionType:  TransactionTypeRefund,

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -85,9 +85,17 @@ const (
 
 const expirationDateXXXX = "XXXX"
 
+const transactionStatusSettledSuccessfully = "settledSuccessfully"
+
 // Request contains a createTransactionRequest for authorizations
 type Request struct {
-	CreateTransactionRequest CreateTransactionRequest `json:"createTransactionRequest"`
+	CreateTransactionRequest     *CreateTransactionRequest     `json:"createTransactionRequest,omitempty"`
+	GetTransactionDetailsRequest *GetTransactionDetailsRequest `json:"getTransactionDetailsRequest,omitempty"`
+}
+
+type GetTransactionDetailsRequest struct {
+	MerchantAuthentication MerchantAuthentication `json:"merchantAuthentication"`
+	TransID                string                 `json:"transId"`
 }
 
 // CreateTransactionRequest specifies the merchant authentication to be used for request as well as transaction
@@ -215,6 +223,21 @@ type TransactionResponse struct {
 	Messages       []TransactionResponseMessage `json:"messages"`
 	Errors         []Error                      `json:"errors"`
 }
+
+type TransactionDetailsResponse struct {
+	GetTransactionDetailsResponse GetTransactionDetailsResponse `json:"getTransactionDetailsResponse"`
+}
+type GetTransactionDetailsResponse struct {
+	Messages    Messages    `json:"messages"`
+	Transaction Transaction `json:"transaction"`
+}
+
+type Transaction struct {
+	ResponseCode      ResponseCode      `json:"responseCode"`
+	TransactionStatus TransactionStatus `json:"transactionStatus"`
+}
+
+type TransactionStatus string
 
 // MessageResponseCode message API response codes specific to AuthorizeNet
 type MessageResponseCode string

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -224,18 +224,17 @@ type TransactionResponse struct {
 	Errors         []Error                      `json:"errors"`
 }
 
-type TransactionDetailsResponse struct {
-	GetTransactionDetailsResponse GetTransactionDetailsResponse `json:"getTransactionDetailsResponse"`
-}
 type GetTransactionDetailsResponse struct {
 	Messages    Messages    `json:"messages"`
 	Transaction Transaction `json:"transaction"`
 }
 
 type Transaction struct {
-	ResponseCode      ResponseCode      `json:"responseCode"`
-	TransactionStatus TransactionStatus `json:"transactionStatus"`
+	TransactionStatus       TransactionStatus       `json:"transactionStatus"`
+	TransactionResponseCode TransactionResponseCode `json:"responseCode"`
 }
+
+type TransactionResponseCode int
 
 type TransactionStatus string
 


### PR DESCRIPTION
Add a request to getTransactionDetailsRequest.

If the transaction is not settled then we should void instead of refund.