### PR TITLE
create & fulfill ClientWithContext functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,13 @@ jobs:
       - run:
           name: Unit Test
           command: |
-            go test -v \
-              -coverpkg $(go list ./... | grep -v integration-tests | grep -v testing | tr '\n' ',' | sed -e 's/.$//') \
-              -coverprofile=unit_coverage.profile -tags=unit \
+            # comma separated list of packages
+            GOCOVER_LIST=$(go list ./... | grep -v integration-tests | grep -v testing | tr '\n' ',' | sed -e 's/.$//')
+            go test \
+              -v \
+              -tags=unit \
+              -coverpkg="$GOCOVER_LIST"  \
+              -coverprofile=unit_coverage.profile \
               $(go list ./... | grep -v integration-tests)
       - run:
           name: Integration Test

--- a/gateways/authorizenet/authorizenet_test.go
+++ b/gateways/authorizenet/authorizenet_test.go
@@ -4,6 +4,7 @@
 package authorizenet
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -76,7 +77,7 @@ func TestSend(t *testing.T) {
 		var want *Response = new(Response)
 		helper.Unmarshal(authResponseRaw, want)
 
-		got, _, err := client.sendRequest(*request)
+		got, _, err := client.sendRequest(context.TODO(), *request)
 
 		if err != nil {
 			t.Fatalf("Error thrown after sending request %q", err)

--- a/gateways/braintree/braintree.go
+++ b/gateways/braintree/braintree.go
@@ -15,6 +15,9 @@ import (
 )
 
 var (
+	// assert client interface
+	_ sleet.ClientWithContext = &BraintreeClient{}
+
 	// make sure to use TLS1.2
 	// https://github.com/braintree-go/braintree-go/blob/a7114170e0095deebe5202ddb07e1bfdb6fcf8d8/braintree.go#L28
 	defaultTransport = &http.Transport{
@@ -66,12 +69,17 @@ func NewWithHttpClient(merchantID string, publicKey string, privateKey string, e
 
 // Authorize a transaction. This transaction must be captured to receive funds
 func (client *BraintreeClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
+	return client.AuthorizeWithContext(context.TODO(), request)
+}
+
+// AuthorizeWithContext authorizes a transaction. This transaction must be captured to receive funds
+func (client *BraintreeClient) AuthorizeWithContext(ctx context.Context, request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
 	authRequest, err := buildAuthRequest(request)
 	if err != nil {
 		return nil, err
 	}
 	btClient := braintree_go.NewWithHttpClient(client.environment, client.merchantID, client.publicKey, client.privateKey, client.httpClient)
-	auth, err := btClient.Transaction().Create(context.TODO(), authRequest)
+	auth, err := btClient.Transaction().Create(ctx, authRequest)
 	if err != nil {
 		var statusCode int
 		if respErr, ok := err.(*braintree_go.BraintreeError); ok && respErr != nil {
@@ -94,12 +102,17 @@ func (client *BraintreeClient) Authorize(request *sleet.AuthorizationRequest) (*
 
 // Capture an authorized transaction with reference and amount
 func (client *BraintreeClient) Capture(request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
+	return client.CaptureWithContext(context.TODO(), request)
+}
+
+// CaptureWithContext captures an authorized transaction with reference and amount
+func (client *BraintreeClient) CaptureWithContext(ctx context.Context, request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
 	amount, err := convertToBraintreeDecimal(request.Amount.Amount, request.Amount.Currency)
 	if err != nil {
 		return nil, err
 	}
 	btClient := braintree_go.NewWithHttpClient(client.environment, client.merchantID, client.publicKey, client.privateKey, client.httpClient)
-	capture, err := btClient.Transaction().SubmitForSettlement(context.TODO(), request.TransactionReference, amount)
+	capture, err := btClient.Transaction().SubmitForSettlement(ctx, request.TransactionReference, amount)
 	if err != nil {
 		return &sleet.CaptureResponse{Success: false, TransactionReference: ""}, err
 	}
@@ -111,8 +124,13 @@ func (client *BraintreeClient) Capture(request *sleet.CaptureRequest) (*sleet.Ca
 
 // Void an authorized transaction with reference (cancels void)
 func (client *BraintreeClient) Void(request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
+	return client.VoidWithContext(context.TODO(), request)
+}
+
+// VoidWithContext voids an authorized transaction with reference (cancels void)
+func (client *BraintreeClient) VoidWithContext(ctx context.Context, request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
 	btClient := braintree_go.NewWithHttpClient(client.environment, client.merchantID, client.publicKey, client.privateKey, client.httpClient)
-	void, err := btClient.Transaction().Void(context.TODO(), request.TransactionReference)
+	void, err := btClient.Transaction().Void(ctx, request.TransactionReference)
 	if err != nil {
 		return &sleet.VoidResponse{
 			Success: false,
@@ -126,12 +144,17 @@ func (client *BraintreeClient) Void(request *sleet.VoidRequest) (*sleet.VoidResp
 
 // Refund a captured transaction with reference and specified amount
 func (client *BraintreeClient) Refund(request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
+	return client.RefundWithContext(context.TODO(), request)
+}
+
+// RefundWithContext captures a captured transaction with reference and specified amount
+func (client *BraintreeClient) RefundWithContext(ctx context.Context, request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
 	amount, err := convertToBraintreeDecimal(request.Amount.Amount, request.Amount.Currency)
 	if err != nil {
 		return nil, err
 	}
 	btClient := braintree_go.NewWithHttpClient(client.environment, client.merchantID, client.publicKey, client.privateKey, client.httpClient)
-	refund, err := btClient.Transaction().Refund(context.TODO(), request.TransactionReference, amount)
+	refund, err := btClient.Transaction().Refund(ctx, request.TransactionReference, amount)
 	if err != nil {
 		return &sleet.RefundResponse{
 			Success: false,

--- a/gateways/cardconnect/cardconnect.go
+++ b/gateways/cardconnect/cardconnect.go
@@ -2,6 +2,7 @@ package cardconnect
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"io/ioutil"
 	"net/http"
@@ -10,6 +11,11 @@ import (
 
 	"github.com/BoltApp/sleet"
 	"github.com/BoltApp/sleet/common"
+)
+
+var (
+	// assert client interface
+	_ sleet.ClientWithContext = &CardConnectClient{}
 )
 
 func NewClient(username string, password string, merchantID string, URL string, environment common.Environment) *CardConnectClient {
@@ -47,7 +53,7 @@ func normalizeURL(URL string) string {
 	return "https://" + URL
 }
 
-func (client *CardConnectClient) sendRequest(request *Request, path string) (*Response, *http.Response, error) {
+func (client *CardConnectClient) sendRequest(ctx context.Context, request *Request, path string) (*Response, *http.Response, error) {
 	request.MerchantID = client.merchantID
 
 	data, err := request.Marshal()
@@ -59,7 +65,7 @@ func (client *CardConnectClient) sendRequest(request *Request, path string) (*Re
 		return nil, nil, err
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(data))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,7 +98,12 @@ func (client *CardConnectClient) sendRequest(request *Request, path string) (*Re
 
 // Authorize a transaction. This transaction must be captured to receive funds
 func (client *CardConnectClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
-	response, httpResponse, err := client.sendRequest(buildAuthorizeParams(request), AuthorizePath)
+	return client.AuthorizeWithContext(context.TODO(), request)
+}
+
+// AuthorizeWithContext authorizes a transaction. This transaction must be captured to receive funds
+func (client *CardConnectClient) AuthorizeWithContext(ctx context.Context, request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
+	response, httpResponse, err := client.sendRequest(ctx, buildAuthorizeParams(request), AuthorizePath)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +132,12 @@ func (client *CardConnectClient) Authorize(request *sleet.AuthorizationRequest) 
 
 // Capture an authorized transaction
 func (client *CardConnectClient) Capture(request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
-	response, httpResponse, err := client.sendRequest(buildCaptureParams(request), CapturePath)
+	return client.CaptureWithContext(context.TODO(), request)
+}
+
+// CaptureWithContext captures an authorized transaction
+func (client *CardConnectClient) CaptureWithContext(ctx context.Context, request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
+	response, httpResponse, err := client.sendRequest(ctx, buildCaptureParams(request), CapturePath)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +156,12 @@ func (client *CardConnectClient) Capture(request *sleet.CaptureRequest) (*sleet.
 
 // Void an authorized transaction
 func (client *CardConnectClient) Void(request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
-	response, httpResponse, err := client.sendRequest(buildVoidParams(request), VoidPath)
+	return client.VoidWithContext(context.TODO(), request)
+}
+
+// VoidWithContext voids an authorized transaction
+func (client *CardConnectClient) VoidWithContext(ctx context.Context, request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
+	response, httpResponse, err := client.sendRequest(ctx, buildVoidParams(request), VoidPath)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +179,12 @@ func (client *CardConnectClient) Void(request *sleet.VoidRequest) (*sleet.VoidRe
 
 // Refund a captured transaction
 func (client *CardConnectClient) Refund(request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
-	response, httpResponse, err := client.sendRequest(buildRefundParams(request), RefundPath)
+	return client.RefundWithContext(context.TODO(), request)
+}
+
+// RefundWithContext refunds a captured transaction
+func (client *CardConnectClient) RefundWithContext(ctx context.Context, request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
+	response, httpResponse, err := client.sendRequest(ctx, buildRefundParams(request), RefundPath)
 	if err != nil {
 		return nil, err
 	}

--- a/gateways/checkoutcom/checkoutcom.go
+++ b/gateways/checkoutcom/checkoutcom.go
@@ -1,14 +1,20 @@
 package checkoutcom
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
-	"github.com/checkout/checkout-sdk-go"
-	"github.com/checkout/checkout-sdk-go/payments"
-
 	"github.com/BoltApp/sleet"
 	"github.com/BoltApp/sleet/common"
+
+	"github.com/checkout/checkout-sdk-go"
+	"github.com/checkout/checkout-sdk-go/payments"
+)
+
+var (
+	// assert client interface
+	_ sleet.ClientWithContext = &CheckoutComClient{}
 )
 
 // checkout.com documentation here: https://www.checkout.com/docs/four/payments/accept-payments, SDK here: https://github.com/checkout/checkout-sdk-go
@@ -52,6 +58,12 @@ func (client *CheckoutComClient) generateCheckoutDCClient() (*payments.Client, e
 
 // Authorize a transaction for specified amount
 func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
+	return client.AuthorizeWithContext(context.TODO(), request)
+}
+
+// AuthorizeWithContext authorizes a transaction for specified amount
+// NOTE -- checkout's SDK does not support context...
+func (client *CheckoutComClient) AuthorizeWithContext(_ context.Context, request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
 	checkoutComClient, err := client.generateCheckoutDCClient()
 	if err != nil {
 		return nil, err
@@ -105,6 +117,12 @@ func (client *CheckoutComClient) Authorize(request *sleet.AuthorizationRequest) 
 
 // Capture an authorized transaction by charge ID
 func (client *CheckoutComClient) Capture(request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
+	return client.CaptureWithContext(context.TODO(), request)
+}
+
+// CaptureWithContext authorizes an authorized transaction by charge ID
+// NOTE -- checkout's SDK does not support context...
+func (client *CheckoutComClient) CaptureWithContext(ctx context.Context, request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
 	checkoutComClient, err := client.generateCheckoutDCClient()
 	if err != nil {
 		return nil, err
@@ -134,6 +152,12 @@ func (client *CheckoutComClient) Capture(request *sleet.CaptureRequest) (*sleet.
 
 // Refund a captured transaction with amount and charge ID
 func (client *CheckoutComClient) Refund(request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
+	return client.RefundWithContext(context.TODO(), request)
+}
+
+// RefundWithContext refunds a captured transaction with amount and charge ID
+// NOTE -- checkout's SDK does not support context...
+func (client *CheckoutComClient) RefundWithContext(ctx context.Context, request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
 	checkoutComClient, err := client.generateCheckoutDCClient()
 	if err != nil {
 		return nil, err
@@ -162,6 +186,12 @@ func (client *CheckoutComClient) Refund(request *sleet.RefundRequest) (*sleet.Re
 
 // Void an authorized transaction with charge ID
 func (client *CheckoutComClient) Void(request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
+	return client.VoidWithContext(context.TODO(), request)
+}
+
+// VoidWithContext voids an authorized transaction with charge ID
+// NOTE -- checkout's SDK does not support context...
+func (client *CheckoutComClient) VoidWithContext(ctx context.Context, request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
 	checkoutComClient, err := client.generateCheckoutDCClient()
 	if err != nil {
 		return nil, err

--- a/gateways/firstdata/firstdata_test.go
+++ b/gateways/firstdata/firstdata_test.go
@@ -4,6 +4,7 @@
 package firstdata
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -146,7 +147,7 @@ func TestSend(t *testing.T) {
 		var want *Response = new(Response)
 		helper.Unmarshal(authResponseRaw, want)
 
-		got, _, err := firstDataClient.sendRequest(defaultReqId, url, *request)
+		got, _, err := firstDataClient.sendRequest(context.TODO(), defaultReqId, url, *request)
 
 		t.Run("Response Struct", func(t *testing.T) {
 			if err != nil {
@@ -206,7 +207,7 @@ func TestSend(t *testing.T) {
 		var want *Response = new(Response)
 		helper.Unmarshal(authErrorRaw, want)
 
-		got, _, err := firstDataClient.sendRequest(defaultReqId, url, *request)
+		got, _, err := firstDataClient.sendRequest(context.TODO(), defaultReqId, url, *request)
 
 		t.Run("Response Struct", func(t *testing.T) {
 			if err != nil {

--- a/gateways/orbital/orbital_test.go
+++ b/gateways/orbital/orbital_test.go
@@ -5,6 +5,7 @@ package orbital
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -100,7 +101,7 @@ func TestSend(t *testing.T) {
 		var want *Response = new(Response)
 		helper.XmlUnmarshal(responseRaw, want)
 
-		got, _, err := client.sendRequest(request)
+		got, _, err := client.sendRequest(context.TODO(), request)
 
 		if err != nil {
 			t.Fatalf("Error thrown after sending request %q", err)

--- a/gateways/paypalpayflow/paypalpayflow.go
+++ b/gateways/paypalpayflow/paypalpayflow.go
@@ -1,6 +1,7 @@
 package paypalpayflow
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -8,6 +9,11 @@ import (
 
 	"github.com/BoltApp/sleet"
 	"github.com/BoltApp/sleet/common"
+)
+
+var (
+	// assert client interface
+	_ sleet.ClientWithContext = &PaypalPayflowClient{}
 )
 
 func NewClient(partner string, password string, vendor string, user string, environment common.Environment) *PaypalPayflowClient {
@@ -33,7 +39,7 @@ func paypalURL(env common.Environment) string {
 	return "https://payflowpro.paypal.com"
 }
 
-func (client *PaypalPayflowClient) sendRequest(request *Request) (*Response, *http.Response, error) {
+func (client *PaypalPayflowClient) sendRequest(ctx context.Context, request *Request) (*Response, *http.Response, error) {
 	data := ""
 	fields := map[string]interface{}{
 		"PARTNER":         client.partner,
@@ -73,7 +79,7 @@ func (client *PaypalPayflowClient) sendRequest(request *Request) (*Response, *ht
 
 	data = strings.TrimLeft(data, "&")
 
-	req, err := http.NewRequest("POST", client.url, strings.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, "POST", client.url, strings.NewReader(data))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -107,7 +113,12 @@ func (client *PaypalPayflowClient) sendRequest(request *Request) (*Response, *ht
 
 // Authorize a transaction. This transaction must be captured to receive funds
 func (client *PaypalPayflowClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
-	response, httpResponse, err := client.sendRequest(buildAuthorizeParams(request))
+	return client.AuthorizeWithContext(context.TODO(), request)
+}
+
+// AuthorizeWithContext a transaction. This transaction must be captured to receive funds
+func (client *PaypalPayflowClient) AuthorizeWithContext(ctx context.Context, request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
+	response, httpResponse, err := client.sendRequest(ctx, buildAuthorizeParams(request))
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +144,12 @@ func (client *PaypalPayflowClient) Authorize(request *sleet.AuthorizationRequest
 
 // Capture an authorized transaction
 func (client *PaypalPayflowClient) Capture(request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
-	response, _, err := client.sendRequest(buildCaptureParams(request))
+	return client.CaptureWithContext(context.TODO(), request)
+}
+
+// CaptureWithContext an authorized transaction
+func (client *PaypalPayflowClient) CaptureWithContext(ctx context.Context, request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
+	response, _, err := client.sendRequest(ctx, buildCaptureParams(request))
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +170,12 @@ func (client *PaypalPayflowClient) Capture(request *sleet.CaptureRequest) (*slee
 
 // Void an authorized transaction
 func (client *PaypalPayflowClient) Void(request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
-	response, _, err := client.sendRequest(buildVoidParams(request))
+	return client.VoidWithContext(context.TODO(), request)
+}
+
+// VoidWithContext an authorized transaction
+func (client *PaypalPayflowClient) VoidWithContext(ctx context.Context, request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
+	response, _, err := client.sendRequest(ctx, buildVoidParams(request))
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +194,12 @@ func (client *PaypalPayflowClient) Void(request *sleet.VoidRequest) (*sleet.Void
 
 // Refund a captured transaction
 func (client *PaypalPayflowClient) Refund(request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
-	response, _, err := client.sendRequest(buildRefundParams(request))
+	return client.RefundWithContext(context.TODO(), request)
+}
+
+// RefundWithContext a captured transaction
+func (client *PaypalPayflowClient) RefundWithContext(ctx context.Context, request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
+	response, _, err := client.sendRequest(ctx, buildRefundParams(request))
 	if err != nil {
 		return nil, err
 	}

--- a/gateways/rocketgate/rocketgate.go
+++ b/gateways/rocketgate/rocketgate.go
@@ -1,6 +1,7 @@
 package rocketgate
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/rocketgate/rocketgate-go-sdk/response"
@@ -8,6 +9,11 @@ import (
 
 	"github.com/BoltApp/sleet"
 	"github.com/BoltApp/sleet/common"
+)
+
+var (
+	// assert client interface
+	_ sleet.ClientWithContext = &RocketgateClient{}
 )
 
 // RocketgateClient represents an HTTP client and the associated authentication information required for
@@ -49,6 +55,12 @@ func NewWithHttpClient(
 
 // Authorize a transaction. This transaction must be captured to receive funds
 func (client *RocketgateClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
+	return client.AuthorizeWithContext(context.TODO(), request)
+}
+
+// AuthorizeWithContext a transaction. This transaction must be captured to receive funds
+// NOTE -- RocketGate's SDK does not support context, this method exists to fulfill the ClientWithContext interface
+func (client *RocketgateClient) AuthorizeWithContext(_ context.Context, request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
 	gatewayService := service.NewGatewayService()
 	gatewayResponse := response.NewGatewayResponse()
 	gatewayRequest := buildAuthRequest(client.merchantID, client.merchantPassword, client.merchantAccount, request)
@@ -76,6 +88,12 @@ func (client *RocketgateClient) Authorize(request *sleet.AuthorizationRequest) (
 
 // Capture an authorized transaction
 func (client *RocketgateClient) Capture(request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
+	return client.CaptureWithContext(context.TODO(), request)
+}
+
+// CaptureWithContext an authorized transaction
+// NOTE -- RocketGate's SDK does not support context, this method exists to fulfill the ClientWithContext interface
+func (client *RocketgateClient) CaptureWithContext(_ context.Context, request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
 	gatewayService := service.NewGatewayService()
 	gatewayResponse := response.NewGatewayResponse()
 	gatewayRequest := buildCaptureRequest(client.merchantID, client.merchantPassword, request)
@@ -99,6 +117,12 @@ func (client *RocketgateClient) Capture(request *sleet.CaptureRequest) (*sleet.C
 
 // Void an authorized transaction
 func (client *RocketgateClient) Void(request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
+	return client.VoidWithContext(context.TODO(), request)
+}
+
+// VoidWithContext an authorized transaction
+// NOTE -- RocketGate's SDK does not support context, this method exists to fulfill the ClientWithContext interface
+func (client *RocketgateClient) VoidWithContext(_ context.Context, request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
 	gatewayService := service.NewGatewayService()
 	gatewayResponse := response.NewGatewayResponse()
 	gatewayRequest := buildVoidRequest(client.merchantID, client.merchantPassword, request)
@@ -121,6 +145,12 @@ func (client *RocketgateClient) Void(request *sleet.VoidRequest) (*sleet.VoidRes
 
 // Refund a captured transaction
 func (client *RocketgateClient) Refund(request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
+	return client.RefundWithContext(context.TODO(), request)
+}
+
+// RefundWithContext a captured transaction
+// NOTE -- RocketGate's SDK does not support context, this method exists to fulfill the ClientWithContext interface
+func (client *RocketgateClient) RefundWithContext(_ context.Context, request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
 	gatewayService := service.NewGatewayService()
 	gatewayResponse := response.NewGatewayResponse()
 	gatewayRequest := buildRefundRequest(client.merchantID, client.merchantPassword, request)

--- a/gateways/stripe/request_builder.go
+++ b/gateways/stripe/request_builder.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/stripe/stripe-go"
@@ -8,8 +9,11 @@ import (
 	"github.com/BoltApp/sleet"
 )
 
-func buildChargeParams(authRequest *sleet.AuthorizationRequest) *stripe.ChargeParams {
+func buildChargeParams(ctx context.Context, authRequest *sleet.AuthorizationRequest) *stripe.ChargeParams {
 	return &stripe.ChargeParams{
+		Params: stripe.Params{
+			Context: ctx,
+		},
 		Amount:   stripe.Int64(authRequest.Amount.Amount),
 		Currency: stripe.String(authRequest.Amount.Currency),
 		Source: &stripe.SourceParams{
@@ -25,21 +29,30 @@ func buildChargeParams(authRequest *sleet.AuthorizationRequest) *stripe.ChargePa
 	}
 }
 
-func buildRefundParams(refundRequest *sleet.RefundRequest) *stripe.RefundParams {
+func buildRefundParams(ctx context.Context, refundRequest *sleet.RefundRequest) *stripe.RefundParams {
 	return &stripe.RefundParams{
+		Params: stripe.Params{
+			Context: ctx,
+		},
 		Amount: stripe.Int64(refundRequest.Amount.Amount),
 		Charge: stripe.String(refundRequest.TransactionReference),
 	}
 }
 
-func buildCaptureParams(captureRequest *sleet.CaptureRequest) *stripe.CaptureParams {
+func buildCaptureParams(ctx context.Context, captureRequest *sleet.CaptureRequest) *stripe.CaptureParams {
 	return &stripe.CaptureParams{
+		Params: stripe.Params{
+			Context: ctx,
+		},
 		Amount: stripe.Int64(captureRequest.Amount.Amount),
 	}
 }
 
-func buildVoidParams(voidRequest *sleet.VoidRequest) *stripe.RefundParams {
+func buildVoidParams(ctx context.Context, voidRequest *sleet.VoidRequest) *stripe.RefundParams {
 	return &stripe.RefundParams{
+		Params: stripe.Params{
+			Context: ctx,
+		},
 		Charge: stripe.String(voidRequest.TransactionReference),
 	}
 }

--- a/gateways/stripe/stripe.go
+++ b/gateways/stripe/stripe.go
@@ -1,18 +1,22 @@
 package stripe
 
 import (
+	"context"
 	"crypto/tls"
 	"net/http"
 	"time"
 
-	"github.com/stripe/stripe-go"
-
+	"github.com/BoltApp/sleet"
 	"github.com/BoltApp/sleet/common"
 
+	"github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/charge"
 	"github.com/stripe/stripe-go/refund"
+)
 
-	"github.com/BoltApp/sleet"
+var (
+	// assert client interface
+	_ sleet.ClientWithContext = &StripeClient{}
 )
 
 // StripeClient uses API-Key and custom http client to make http calls
@@ -48,8 +52,13 @@ func NewWithHTTPClient(apiKey string, httpClient *http.Client) *StripeClient {
 
 // Authorize a transaction for specified amount using stripe-go library
 func (client *StripeClient) Authorize(request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
+	return client.AuthorizeWithContext(context.TODO(), request)
+}
+
+// AuthorizeWithContext a transaction for specified amount using stripe-go library
+func (client *StripeClient) AuthorizeWithContext(ctx context.Context, request *sleet.AuthorizationRequest) (*sleet.AuthorizationResponse, error) {
 	chargeClient := charge.Client{B: stripe.GetBackend(stripe.APIBackend), Key: client.apiKey}
-	charge, err := chargeClient.New(buildChargeParams(request))
+	charge, err := chargeClient.New(buildChargeParams(ctx, request))
 	if err != nil {
 		return &sleet.AuthorizationResponse{Success: false, TransactionReference: "", AvsResult: sleet.AVSResponseUnknown, CvvResult: sleet.CVVResponseUnknown, ErrorCode: err.Error()}, err
 	}
@@ -64,8 +73,13 @@ func (client *StripeClient) Authorize(request *sleet.AuthorizationRequest) (*sle
 
 // Capture an authorized transaction by charge ID
 func (client *StripeClient) Capture(request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
+	return client.CaptureWithContext(context.TODO(), request)
+}
+
+// CaptureWithContext an authorized transaction by charge ID
+func (client *StripeClient) CaptureWithContext(ctx context.Context, request *sleet.CaptureRequest) (*sleet.CaptureResponse, error) {
 	chargeClient := charge.Client{B: stripe.GetBackend(stripe.APIBackend), Key: client.apiKey}
-	capture, err := chargeClient.Capture(request.TransactionReference, buildCaptureParams(request))
+	capture, err := chargeClient.Capture(request.TransactionReference, buildCaptureParams(ctx, request))
 	if err != nil {
 		return &sleet.CaptureResponse{Success: false, ErrorCode: common.SPtr(err.Error())}, nil
 	}
@@ -74,8 +88,13 @@ func (client *StripeClient) Capture(request *sleet.CaptureRequest) (*sleet.Captu
 
 // Refund a captured transaction with amount and charge ID
 func (client *StripeClient) Refund(request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
+	return client.RefundWithContext(context.TODO(), request)
+}
+
+// RefundWithContext a captured transaction with amount and charge ID
+func (client *StripeClient) RefundWithContext(ctx context.Context, request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
 	refundClient := refund.Client{B: stripe.GetBackend(stripe.APIBackend), Key: client.apiKey}
-	refund, err := refundClient.New(buildRefundParams(request))
+	refund, err := refundClient.New(buildRefundParams(ctx, request))
 	if err != nil {
 		return &sleet.RefundResponse{Success: false, ErrorCode: common.SPtr(err.Error())}, nil
 	}
@@ -84,8 +103,13 @@ func (client *StripeClient) Refund(request *sleet.RefundRequest) (*sleet.RefundR
 
 // Void an authorized transaction with charge ID
 func (client *StripeClient) Void(request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
+	return client.VoidWithContext(context.TODO(), request)
+}
+
+// VoidWithContext an authorized transaction with charge ID
+func (client *StripeClient) VoidWithContext(ctx context.Context, request *sleet.VoidRequest) (*sleet.VoidResponse, error) {
 	voidClient := refund.Client{B: stripe.GetBackend(stripe.APIBackend), Key: client.apiKey}
-	void, err := voidClient.New(buildVoidParams(request))
+	void, err := voidClient.New(buildVoidParams(ctx, request))
 	if err != nil {
 		return &sleet.VoidResponse{Success: false, ErrorCode: common.SPtr(err.Error())}, nil
 	}

--- a/types.go
+++ b/types.go
@@ -1,6 +1,7 @@
 package sleet
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -13,6 +14,16 @@ type Client interface {
 	Capture(request *CaptureRequest) (*CaptureResponse, error)
 	Void(request *VoidRequest) (*VoidResponse, error)
 	Refund(request *RefundRequest) (*RefundResponse, error)
+}
+
+// ClientWithContext is a superset of `Client` that includes addtional methods that take
+// `context.Context` as parameters.
+type ClientWithContext interface {
+	Client // supset includes the normal Client interface
+	AuthorizeWithContext(ctx context.Context, request *AuthorizationRequest) (*AuthorizationResponse, error)
+	CaptureWithContext(ctx context.Context, request *CaptureRequest) (*CaptureResponse, error)
+	VoidWithContext(ctx context.Context, request *VoidRequest) (*VoidResponse, error)
+	RefundWithContext(ctx context.Context, request *RefundRequest) (*RefundResponse, error)
 }
 
 // Amount specifies both quantity and currency


### PR DESCRIPTION
Creates a set of parallel methods that take a `context.Context` argument
for all payment gateways. They all follow the same pattern of passing
through `X` to `XWithContext`.

notes:
- Checkout.com & Rocketgate's SDK's do not allow a context variable to be supplied
- Adyen chose an _interesting_ way to patch `context.Context` onto their SDK