### PR TITLE
Add Auth Net Auth Endpoint Support for Google Pay Tokens

### DIFF
--- a/gateways/adyen/request_builder.go
+++ b/gateways/adyen/request_builder.go
@@ -20,9 +20,8 @@ const (
 
 // Options
 const (
-	applePayTokenOption  = "ApplePayToken"
-	googlePayTokenOption = "GooglePayToken"
-	shopperIPOption      = "ShopperIP"
+	applePayTokenOption = "ApplePayToken"
+	shopperIPOption     = "ShopperIP"
 )
 
 // Shopper Interactions
@@ -125,10 +124,10 @@ func addPaymentSpecificFields(authRequest *sleet.AuthorizationRequest, request *
 			"type":          "applepay",
 			"applePayToken": authRequest.Options[applePayTokenOption].(string),
 		}
-	} else if authRequest.Options[googlePayTokenOption] != nil {
+	} else if authRequest.Options[sleet.GooglePayTokenOption] != nil {
 		request.PaymentMethod = map[string]interface{}{
 			"type":           "googlepay",
-			"googlePayToken": authRequest.Options[googlePayTokenOption].(string),
+			"googlePayToken": authRequest.Options[sleet.GooglePayTokenOption].(string),
 		}
 	} else {
 		request.PaymentMethod = map[string]interface{}{

--- a/gateways/adyen/request_builder_test.go
+++ b/gateways/adyen/request_builder_test.go
@@ -31,7 +31,7 @@ func TestBuildAuthRequest(t *testing.T) {
 
 	requestWithGooglePayToken := sleet_testing.BaseAuthorizationRequest()
 	requestWithGooglePayToken.CreditCard.CVV = ""
-	requestWithGooglePayToken.Options = map[string]interface{}{googlePayTokenOption: "testGooglePayToken"}
+	requestWithGooglePayToken.Options = map[string]interface{}{sleet.GooglePayTokenOption: "testGooglePayToken"}
 
 	baseWithAydenData := sleet_testing.BaseAuthorizationRequest()
 	enhanceBaseAuthorizationDataWithAdditionalFields(baseWithAydenData)

--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -1,6 +1,7 @@
 package authorizenet
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -42,13 +43,15 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 	var transactionRequest TransactionRequest
 	if authRequest.Options[sleet.GooglePayTokenOption] != nil {
 		// Google Pay request
+		googlePayToken := authRequest.Options[sleet.GooglePayTokenOption].(string)
+		encodedGooglePayToken := base64.StdEncoding.EncodeToString([]byte(googlePayToken))
 		transactionRequest = TransactionRequest{
 			TransactionType: TransactionTypeAuthCapture,
 			Amount:          &amountStr,
 			Payment: &Payment{
 				OpaqueData: OpaqueData{
 					DataDescriptor: GooglePayPaymentDescriptor,
-					DataValue:      authRequest.Options[sleet.GooglePayTokenOption].(string),
+					DataValue:      encodedGooglePayToken,
 				},
 			},
 		}

--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -37,7 +37,23 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 
 	authorizeRequest := CreateTransactionRequest{
 		MerchantAuthentication: authentication(merchantName, transactionKey),
-		TransactionRequest: TransactionRequest{
+	}
+
+	var transactionRequest TransactionRequest
+	if authRequest.Options[sleet.GooglePayTokenOption] != nil {
+		// Google Pay request
+		transactionRequest = TransactionRequest{
+			TransactionType: TransactionTypeAuthCapture,
+			Amount:          &amountStr,
+			Payment: &Payment{
+				OpaqueData: OpaqueData{
+					DataDescriptor: GooglePayPaymentDescriptor,
+					DataValue:      authRequest.Options[sleet.GooglePayTokenOption].(string),
+				},
+			},
+		}
+	} else {
+		transactionRequest = TransactionRequest{
 			TransactionType: TransactionTypeAuthOnly,
 			Amount:          &amountStr,
 			Payment: &Payment{
@@ -47,8 +63,9 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 				FirstName: authRequest.CreditCard.FirstName,
 				LastName:  authRequest.CreditCard.LastName,
 			},
-		},
+		}
 	}
+	authorizeRequest.TransactionRequest = transactionRequest
 
 	if billingAddress != nil {
 		authorizeRequest.TransactionRequest.BillingAddress = &BillingAddress{

--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -49,7 +49,7 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 			TransactionType: TransactionTypeAuthCapture,
 			Amount:          &amountStr,
 			Payment: &Payment{
-				OpaqueData: OpaqueData{
+				OpaqueData: &OpaqueData{
 					DataDescriptor: GooglePayPaymentDescriptor,
 					DataValue:      encodedGooglePayToken,
 				},
@@ -60,7 +60,7 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 			TransactionType: TransactionTypeAuthOnly,
 			Amount:          &amountStr,
 			Payment: &Payment{
-				CreditCard: creditCard,
+				CreditCard: &creditCard,
 			},
 			BillingAddress: &BillingAddress{
 				FirstName: authRequest.CreditCard.FirstName,
@@ -144,7 +144,7 @@ func buildRefundRequest(merchantName string, transactionKey string, refundReques
 				Amount:           &amountStr,
 				RefTransactionID: &refundRequest.TransactionReference,
 				Payment: &Payment{
-					CreditCard: CreditCard{
+					CreditCard: &CreditCard{
 						CardNumber:     refundRequest.Last4,
 						ExpirationDate: expirationDateXXXX,
 					},

--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -46,7 +46,7 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 		googlePayToken := authRequest.Options[sleet.GooglePayTokenOption].(string)
 		encodedGooglePayToken := base64.StdEncoding.EncodeToString([]byte(googlePayToken))
 		transactionRequest = TransactionRequest{
-			TransactionType: TransactionTypeAuthCapture,
+			TransactionType: TransactionTypeAuthOnly,
 			Amount:          &amountStr,
 			Payment: &Payment{
 				OpaqueData: &OpaqueData{

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -4,6 +4,7 @@
 package authorizenet
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
@@ -138,7 +139,7 @@ func TestBuildAuthRequest(t *testing.T) {
 						Payment: &Payment{
 							OpaqueData: OpaqueData{
 								DataDescriptor: GooglePayPaymentDescriptor,
-								DataValue:      "testGooglePayToken",
+								DataValue:      base64.StdEncoding.EncodeToString([]byte("testGooglePayToken")),
 							},
 						},
 						BillingAddress: &BillingAddress{

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -54,7 +54,7 @@ func TestBuildAuthRequest(t *testing.T) {
 						TransactionType: TransactionTypeAuthOnly,
 						Amount:          &amount,
 						Payment: &Payment{
-							CreditCard: CreditCard{
+							CreditCard: &CreditCard{
 								CardNumber:     "4111111111111111",
 								ExpirationDate: "2023-10",
 								CardCode:       base.CreditCard.CVV,
@@ -96,7 +96,7 @@ func TestBuildAuthRequest(t *testing.T) {
 						TransactionType: TransactionTypeAuthOnly,
 						Amount:          &amount,
 						Payment: &Payment{
-							CreditCard: CreditCard{
+							CreditCard: &CreditCard{
 								CardNumber:     "4111111111111111",
 								ExpirationDate: "2023-10",
 								IsPaymentToken: common.BPtr(true),
@@ -137,7 +137,7 @@ func TestBuildAuthRequest(t *testing.T) {
 						TransactionType: TransactionTypeAuthCapture,
 						Amount:          &amount,
 						Payment: &Payment{
-							OpaqueData: OpaqueData{
+							OpaqueData: &OpaqueData{
 								DataDescriptor: GooglePayPaymentDescriptor,
 								DataValue:      base64.StdEncoding.EncodeToString([]byte("testGooglePayToken")),
 							},
@@ -169,7 +169,7 @@ func TestBuildAuthRequest(t *testing.T) {
 						TransactionType: TransactionTypeAuthOnly,
 						Amount:          &amount,
 						Payment: &Payment{
-							CreditCard: CreditCard{
+							CreditCard: &CreditCard{
 								CardNumber:     "4111111111111111",
 								ExpirationDate: "2023-10",
 								CardCode:       base.CreditCard.CVV,
@@ -224,7 +224,7 @@ func TestBuildAuthRequest(t *testing.T) {
 						TransactionType: TransactionTypeAuthOnly,
 						Amount:          &amount,
 						Payment: &Payment{
-							CreditCard: CreditCard{
+							CreditCard: &CreditCard{
 								CardNumber:     "4111111111111111",
 								ExpirationDate: "2023-10",
 								CardCode:       base.CreditCard.CVV,
@@ -279,7 +279,7 @@ func TestBuildAuthRequest(t *testing.T) {
 						TransactionType: TransactionTypeAuthOnly,
 						Amount:          &amount,
 						Payment: &Payment{
-							CreditCard: CreditCard{
+							CreditCard: &CreditCard{
 								CardNumber:     "4111111111111111",
 								ExpirationDate: "2023-10",
 								CardCode:       withCustomerIP.CreditCard.CVV,
@@ -322,7 +322,7 @@ func TestBuildAuthRequest(t *testing.T) {
 						TransactionType: TransactionTypeAuthOnly,
 						Amount:          &amount,
 						Payment: &Payment{
-							CreditCard: CreditCard{
+							CreditCard: &CreditCard{
 								CardNumber:     "4111111111111111",
 								ExpirationDate: "2023-10",
 								CardCode:       base.CreditCard.CVV,
@@ -445,7 +445,7 @@ func TestBuildRefundRequest(t *testing.T) {
 							Amount:           &amount,
 							RefTransactionID: &base.TransactionReference,
 							Payment: &Payment{
-								CreditCard: CreditCard{
+								CreditCard: &CreditCard{
 									CardNumber:     "1111",
 									ExpirationDate: expirationDateXXXX,
 								},

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -127,6 +127,7 @@ func TestBuildAuthRequest(t *testing.T) {
 				BillingAddress:             base.BillingAddress,
 				ClientTransactionReference: base.ClientTransactionReference,
 				Options:                    map[string]interface{}{sleet.GooglePayTokenOption: "testGooglePayToken"},
+				Cryptogram:                 "testGooglePayToken",
 			},
 			&Request{
 				CreateTransactionRequest: CreateTransactionRequest{
@@ -137,7 +138,7 @@ func TestBuildAuthRequest(t *testing.T) {
 						Payment: &Payment{
 							OpaqueData: OpaqueData{
 								DataDescriptor: GooglePayPaymentDescriptor,
-								DataValue:      authRequest.Options[sleet.GooglePayTokenOption].(string),
+								DataValue:      "testGooglePayToken",
 							},
 						},
 						BillingAddress: &BillingAddress{

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -134,7 +134,7 @@ func TestBuildAuthRequest(t *testing.T) {
 				CreateTransactionRequest: CreateTransactionRequest{
 					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
 					TransactionRequest: TransactionRequest{
-						TransactionType: TransactionTypeAuthCapture,
+						TransactionType: TransactionTypeAuthOnly,
 						Amount:          &amount,
 						Payment: &Payment{
 							OpaqueData: &OpaqueData{

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -120,6 +120,44 @@ func TestBuildAuthRequest(t *testing.T) {
 			},
 		},
 		{
+			"Google Pay Auth Request",
+			&sleet.AuthorizationRequest{
+				Amount:                     base.Amount,
+				CreditCard:                 base.CreditCard,
+				BillingAddress:             base.BillingAddress,
+				ClientTransactionReference: base.ClientTransactionReference,
+				Options:                    map[string]interface{}{sleet.GooglePayTokenOption: "testGooglePayToken"},
+			},
+			&Request{
+				CreateTransactionRequest: CreateTransactionRequest{
+					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
+					TransactionRequest: TransactionRequest{
+						TransactionType: TransactionTypeAuthCapture,
+						Amount:          &amount,
+						Payment: &Payment{
+							OpaqueData: OpaqueData{
+								DataDescriptor: GooglePayPaymentDescriptor,
+								DataValue:      authRequest.Options[sleet.GooglePayTokenOption].(string),
+							},
+						},
+						BillingAddress: &BillingAddress{
+							FirstName:   "Bolt",
+							LastName:    "Checkout",
+							Address:     base.BillingAddress.StreetAddress1,
+							City:        base.BillingAddress.Locality,
+							State:       base.BillingAddress.RegionCode,
+							Zip:         base.BillingAddress.PostalCode,
+							Country:     base.BillingAddress.CountryCode,
+							PhoneNumber: base.BillingAddress.PhoneNumber,
+						},
+						Customer: &Customer{
+							Email: *base.BillingAddress.Email,
+						},
+					},
+				},
+			},
+		},
+		{
 			"L2L3 Data",
 			baseL2L3,
 			&Request{

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -156,8 +156,8 @@ type Customer struct {
 
 // Payment specifies the credit card to be authorized (only payment option for now)
 type Payment struct {
-	CreditCard CreditCard `json:"creditCard"`
-	OpaqueData OpaqueData `json:"opaqueData"`
+	CreditCard *CreditCard `json:"creditCard,omitempty"`
+	OpaqueData *OpaqueData `json:"opaqueData,omitempty"`
 }
 
 // OpaqueData Contains dataDescriptor and dataValue

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -6,6 +6,7 @@ type TransactionType string
 
 const (
 	TransactionTypeAuthOnly         TransactionType = "authOnlyTransaction"
+	TransactionTypeAuthCapture      TransactionType = "authCaptureTransaction"
 	TransactionTypeVoid             TransactionType = "voidTransaction"
 	TransactionTypePriorAuthCapture TransactionType = "priorAuthCaptureTransaction"
 	TransactionTypeRefund           TransactionType = "refundTransaction"
@@ -23,6 +24,10 @@ const (
 
 const (
 	MessageResponseCodeAlreadyCaptured = "311"
+)
+
+const (
+	GooglePayPaymentDescriptor = "COMMON.GOOGLE.INAPP.PAYMENT"
 )
 
 // ResultCode result of request (ok/error)
@@ -152,6 +157,15 @@ type Customer struct {
 // Payment specifies the credit card to be authorized (only payment option for now)
 type Payment struct {
 	CreditCard CreditCard `json:"creditCard"`
+	OpaqueData OpaqueData `json:"opaqueData"`
+}
+
+// OpaqueData Contains dataDescriptor and dataValue
+// dataDescriptor Specifies how the request should be processed.
+// dataValue Base64 encoded data that contains encrypted payment data known as the payment nonce. The nonce is valid for 15 minutes
+type OpaqueData struct {
+	DataDescriptor string `json:"dataDescriptor"`
+	DataValue      string `json:"dataValue"`
 }
 
 // CreditCard is raw cc info

--- a/types.go
+++ b/types.go
@@ -89,6 +89,7 @@ type Level3Data struct {
 
 const (
 	ResponseHeaderOption string = "ResponseHeader"
+	GooglePayTokenOption string = "GooglePayToken"
 )
 
 // AuthorizationRequest specifies needed information for request to authorize by PsPs


### PR DESCRIPTION
Google Pay tokens can now be passed through the sleet request and will build a Google Pay specific request to hit the auth endpoint with