### PR TITLE
Remove Base64 encode for authnet Gpay token

### DIFF
--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -48,7 +48,7 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 			Payment: &Payment{
 				OpaqueData: &OpaqueData{
 					DataDescriptor: GooglePayPaymentDescriptor,
-					DataValue:      authRequest.Options[sleet.GooglePayTokenOption].([]byte),
+					DataValue:      authRequest.Options[sleet.GooglePayTokenOption].(string),
 				},
 			},
 		}

--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -48,7 +48,7 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 			Payment: &Payment{
 				OpaqueData: &OpaqueData{
 					DataDescriptor: GooglePayPaymentDescriptor,
-					DataValue:      authRequest.Options[sleet.GooglePayTokenOption].(string),
+					DataValue:      authRequest.Options[sleet.GooglePayTokenOption].([]byte),
 				},
 			},
 		}

--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -1,7 +1,6 @@
 package authorizenet
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -43,15 +42,13 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 	var transactionRequest TransactionRequest
 	if authRequest.Options[sleet.GooglePayTokenOption] != nil {
 		// Google Pay request
-		googlePayToken := authRequest.Options[sleet.GooglePayTokenOption].(string)
-		encodedGooglePayToken := base64.StdEncoding.EncodeToString([]byte(googlePayToken))
 		transactionRequest = TransactionRequest{
 			TransactionType: TransactionTypeAuthOnly,
 			Amount:          &amountStr,
 			Payment: &Payment{
 				OpaqueData: &OpaqueData{
 					DataDescriptor: GooglePayPaymentDescriptor,
-					DataValue:      encodedGooglePayToken,
+					DataValue:      authRequest.Options[sleet.GooglePayTokenOption].(string),
 				},
 			},
 		}

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -4,7 +4,6 @@
 package authorizenet
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"testing"
 
@@ -139,7 +138,7 @@ func TestBuildAuthRequest(t *testing.T) {
 						Payment: &Payment{
 							OpaqueData: &OpaqueData{
 								DataDescriptor: GooglePayPaymentDescriptor,
-								DataValue:      base64.StdEncoding.EncodeToString([]byte("testGooglePayToken")),
+								DataValue:      "testGooglePayToken",
 							},
 						},
 						BillingAddress: &BillingAddress{

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -165,7 +165,7 @@ type Payment struct {
 // dataValue Base64 encoded data that contains encrypted payment data known as the payment nonce. The nonce is valid for 15 minutes
 type OpaqueData struct {
 	DataDescriptor string `json:"dataDescriptor"`
-	DataValue      []byte `json:"dataValue"`
+	DataValue      string `json:"dataValue"`
 }
 
 // CreditCard is raw cc info

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -165,7 +165,7 @@ type Payment struct {
 // dataValue Base64 encoded data that contains encrypted payment data known as the payment nonce. The nonce is valid for 15 minutes
 type OpaqueData struct {
 	DataDescriptor string `json:"dataDescriptor"`
-	DataValue      string `json:"dataValue"`
+	DataValue      []byte `json:"dataValue"`
 }
 
 // CreditCard is raw cc info


### PR DESCRIPTION
Authorize Net has wrong documentation.

https://developer.authorize.net/api/reference/features/in-app.html

The token we get back from Google Pay is already base64 encoded.