### PR TITLE
Fix adyen APIError failure response

### DIFF
--- a/gateways/adyen/adyen.go
+++ b/gateways/adyen/adyen.go
@@ -81,7 +81,7 @@ func (client *AdyenClient) AuthorizeWithContext(ctx context.Context, request *sl
 				ErrorCode:  adyenError.Code,
 				Message:    adyenError.Message,
 				ResultType: sleet.ResultTypeAPIError,
-			}, err
+			}, nil
 		}
 		return &sleet.AuthorizationResponse{
 			Success:              false,

--- a/integration-tests/adyen_test.go
+++ b/integration-tests/adyen_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/BoltApp/sleet"
@@ -18,13 +17,9 @@ func TestAdyenAuthorizeFailed(t *testing.T) {
 	failedRequest := adyenBaseAuthRequest()
 	// set ClientTransactionReference to be empty
 	failedRequest.ClientTransactionReference = sPtr("")
-	auth, err := client.Authorize(failedRequest)
-	if err == nil {
+	auth, _ := client.Authorize(failedRequest)
+	if auth.Success == true {
 		t.Error("Authorize request should have failed with missing reference")
-	}
-
-	if !strings.Contains(err.Error(), "'reference' is not provided") {
-		t.Errorf("Response should contain missing reference error, response - %s", err.Error())
 	}
 
 	if auth.ResultType != sleet.ResultTypeAPIError {


### PR DESCRIPTION
Don't return an go error when response is correctly modelled.