### PR TITLE
Update Authorize Net to support Google Pay Refunds

### DIFF
--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/BoltApp/sleet"
-	"github.com/BoltApp/sleet/common"
 	"io/ioutil"
 	"net/http"
 	"strconv"
+
+	"github.com/BoltApp/sleet"
+	"github.com/BoltApp/sleet/common"
 )
 
 var (

--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -135,7 +135,7 @@ func (client *AuthorizeNetClient) RefundWithContext(ctx context.Context, request
 	}
 
 	var transactionDetailsResponse *sleet.TransactionDetailsResponse
-	if request.Options != nil {
+	if request.Options != nil && request.Options[sleet.GooglePayTokenOption] != nil {
 		var boolValue bool
 		boolValue, _ = strconv.ParseBool(request.Options[sleet.GooglePayTokenOption].(string))
 		if boolValue {

--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -131,6 +131,9 @@ func (client *AuthorizeNetClient) RefundWithContext(ctx context.Context, request
 	transactionDetailsResponse, err := client.GetTransactionDetails(&sleet.TransactionDetailsRequest{
 		TransactionReference: request.TransactionReference,
 	})
+	if err != nil {
+		return nil, err
+	}
 	creditCardNumber := transactionDetailsResponse.CardNumber
 	last4 := creditCardNumber[len(creditCardNumber)-4:]
 	request.Last4 = last4

--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -129,15 +129,18 @@ func (client *AuthorizeNetClient) Refund(request *sleet.RefundRequest) (*sleet.R
 
 // RefundWithContext refunds a captured transaction with amount and captured transaction reference
 func (client *AuthorizeNetClient) RefundWithContext(ctx context.Context, request *sleet.RefundRequest) (*sleet.RefundResponse, error) {
-	transactionDetailsResponse, err := client.GetTransactionDetails(&sleet.TransactionDetailsRequest{
-		TransactionReference: request.TransactionReference,
-	})
-	if err != nil {
-		return nil, err
+
+	if request.Options != nil && request.Options[sleet.GooglePayTokenOption] != nil {
+		transactionDetailsResponse, err := client.GetTransactionDetails(&sleet.TransactionDetailsRequest{
+			TransactionReference: request.TransactionReference,
+		})
+		if err != nil {
+			return nil, err
+		}
+		creditCardNumber := transactionDetailsResponse.CardNumber
+		last4 := creditCardNumber[len(creditCardNumber)-4:]
+		request.Last4 = last4
 	}
-	creditCardNumber := transactionDetailsResponse.CardNumber
-	last4 := creditCardNumber[len(creditCardNumber)-4:]
-	request.Last4 = last4
 
 	authorizeNetRefundRequest, err := buildRefundRequest(client.merchantName, client.transactionKey, request)
 	if err != nil {

--- a/gateways/authorizenet/authorizenet.go
+++ b/gateways/authorizenet/authorizenet.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/BoltApp/sleet"
-	"github.com/BoltApp/sleet/common"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/BoltApp/sleet"
+	"github.com/BoltApp/sleet/common"
 )
 
 var (

--- a/gateways/authorizenet/authorizenet_test.go
+++ b/gateways/authorizenet/authorizenet_test.go
@@ -319,6 +319,12 @@ func TestRefund(t *testing.T) {
 	t.Run("With Success Response", func(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
+		
+		httpmock.RegisterResponder("POST", url, func(req *http.Request) (*http.Response, error) {
+			transactionDetailsResponseRaw := helper.ReadFile("test_data/transactionDetailsSuccessResponse.json")
+			resp := httpmock.NewBytesResponse(http.StatusOK, transactionDetailsResponseRaw)
+			return resp, nil
+		})
 
 		request := sleet_t.BaseRefundRequest()
 		httpmock.RegisterResponder("POST", url, func(req *http.Request) (*http.Response, error) {

--- a/gateways/authorizenet/authorizenet_test.go
+++ b/gateways/authorizenet/authorizenet_test.go
@@ -319,7 +319,7 @@ func TestRefund(t *testing.T) {
 	t.Run("With Success Response", func(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
-		
+
 		httpmock.RegisterResponder("POST", url, func(req *http.Request) (*http.Response, error) {
 			transactionDetailsResponseRaw := helper.ReadFile("test_data/transactionDetailsSuccessResponse.json")
 			resp := httpmock.NewBytesResponse(http.StatusOK, transactionDetailsResponseRaw)

--- a/gateways/authorizenet/authorizenet_test.go
+++ b/gateways/authorizenet/authorizenet_test.go
@@ -395,6 +395,74 @@ func TestRefund(t *testing.T) {
 	})
 }
 
+func TestGetTransactionDetails(t *testing.T) {
+	helper := sleet_t.NewTestHelper(t)
+	url := "https://apitest.authorize.net/xml/v1/request.api"
+
+	t.Run("With Success Response", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		request := &sleet.TransactionDetailsRequest{
+			TransactionReference: "1234569999",
+		}
+		httpmock.RegisterResponder("POST", url, func(req *http.Request) (*http.Response, error) {
+			transactionDetailsResponseRaw := helper.ReadFile("test_data/transactionDetailsSuccessResponse.json")
+			resp := httpmock.NewBytesResponse(http.StatusOK, transactionDetailsResponseRaw)
+			return resp, nil
+		})
+
+		want := &sleet.TransactionDetailsResponse{
+			ResultCode: "Ok",
+			CardNumber: "XXXX1111",
+		}
+
+		client := NewClient("MerchantName", "Key", common.Sandbox)
+
+		got, err := client.GetTransactionDetails(request)
+
+		if err != nil {
+			t.Fatalf("Error thrown after sending request %q", err)
+		}
+
+		if !cmp.Equal(*got, *want, sleet_t.CompareUnexported) {
+			t.Error("Response body does not match expected")
+			t.Error(cmp.Diff(*want, *got, sleet_t.CompareUnexported))
+		}
+	})
+
+	t.Run("With Error Response", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		request := &sleet.TransactionDetailsRequest{
+			TransactionReference: "1234569999",
+		}
+		httpmock.RegisterResponder("POST", url, func(req *http.Request) (*http.Response, error) {
+			transactionDetailsResponseRaw := helper.ReadFile("test_data/transactionDetailsErrorResponse.json")
+			resp := httpmock.NewBytesResponse(http.StatusOK, transactionDetailsResponseRaw)
+			return resp, nil
+		})
+
+		want := &sleet.TransactionDetailsResponse{
+			ResultCode: string(ResultCodeError),
+		}
+
+		client := NewClient("MerchantName", "Key", common.Sandbox)
+
+		got, err := client.GetTransactionDetails(request)
+
+		if err != nil {
+			t.Fatalf("Error thrown after sending request %q", err)
+		}
+
+		if !cmp.Equal(*got, *want, sleet_t.CompareUnexported) {
+			t.Error("Response body does not match expected")
+			t.Error(cmp.Diff(*want, *got, sleet_t.CompareUnexported))
+		}
+	})
+}
+
 func TestAlreadyCaptured(t *testing.T) {
 	helper := sleet_t.NewTestHelper(t)
 

--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -260,3 +260,16 @@ func buildLineItemsString(authRequest *sleet.AuthorizationRequest) *string {
 	}
 	return nil
 }
+
+func BuildTransactionDetailsRequest(merchantName string, transactionKey string, transactionDetailsRequest *sleet.TransactionDetailsRequest) (
+	*Request,
+	error,
+) {
+	request := &Request{
+		GetTransactionDetailsRequest: GetTransactionDetailsRequest{
+			MerchantAuthentication: authentication(merchantName, transactionKey),
+			TransID:                transactionDetailsRequest.TransactionReference,
+		},
+	}
+	return request, nil
+}

--- a/gateways/authorizenet/request_builders.go
+++ b/gateways/authorizenet/request_builders.go
@@ -101,12 +101,12 @@ func buildAuthRequest(merchantName string, transactionKey string, authRequest *s
 		}
 	}
 
-	return &Request{CreateTransactionRequest: authorizeRequest}
+	return &Request{CreateTransactionRequest: &authorizeRequest}
 }
 
 func buildVoidRequest(merchantName string, transactionKey string, voidRequest *sleet.VoidRequest) *Request {
 	return &Request{
-		CreateTransactionRequest: CreateTransactionRequest{
+		CreateTransactionRequest: &CreateTransactionRequest{
 			MerchantAuthentication: authentication(merchantName, transactionKey),
 			TransactionRequest: TransactionRequest{
 				TransactionType:  TransactionTypeVoid,
@@ -119,7 +119,7 @@ func buildVoidRequest(merchantName string, transactionKey string, voidRequest *s
 func buildCaptureRequest(merchantName string, transactionKey string, captureRequest *sleet.CaptureRequest) *Request {
 	amountStr := sleet.AmountToDecimalString(captureRequest.Amount)
 	request := &Request{
-		CreateTransactionRequest: CreateTransactionRequest{
+		CreateTransactionRequest: &CreateTransactionRequest{
 			MerchantAuthentication: authentication(merchantName, transactionKey),
 			TransactionRequest: TransactionRequest{
 				TransactionType:  TransactionTypePriorAuthCapture,
@@ -137,7 +137,7 @@ func buildRefundRequest(merchantName string, transactionKey string, refundReques
 ) {
 	amountStr := sleet.AmountToDecimalString(refundRequest.Amount)
 	request := &Request{
-		CreateTransactionRequest: CreateTransactionRequest{
+		CreateTransactionRequest: &CreateTransactionRequest{
 			MerchantAuthentication: authentication(merchantName, transactionKey),
 			TransactionRequest: TransactionRequest{
 				TransactionType:  TransactionTypeRefund,
@@ -266,7 +266,7 @@ func BuildTransactionDetailsRequest(merchantName string, transactionKey string, 
 	error,
 ) {
 	request := &Request{
-		GetTransactionDetailsRequest: GetTransactionDetailsRequest{
+		GetTransactionDetailsRequest: &GetTransactionDetailsRequest{
 			MerchantAuthentication: authentication(merchantName, transactionKey),
 			TransID:                transactionDetailsRequest.TransactionReference,
 		},

--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -48,7 +48,7 @@ func TestBuildAuthRequest(t *testing.T) {
 			"Basic Auth Request",
 			base,
 			&Request{
-				CreateTransactionRequest: CreateTransactionRequest{
+				CreateTransactionRequest: &CreateTransactionRequest{
 					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
 					TransactionRequest: TransactionRequest{
 						TransactionType: TransactionTypeAuthOnly,
@@ -90,7 +90,7 @@ func TestBuildAuthRequest(t *testing.T) {
 				Cryptogram:                 "cryptogram",
 			},
 			&Request{
-				CreateTransactionRequest: CreateTransactionRequest{
+				CreateTransactionRequest: &CreateTransactionRequest{
 					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
 					TransactionRequest: TransactionRequest{
 						TransactionType: TransactionTypeAuthOnly,
@@ -131,7 +131,7 @@ func TestBuildAuthRequest(t *testing.T) {
 				Cryptogram:                 "testGooglePayToken",
 			},
 			&Request{
-				CreateTransactionRequest: CreateTransactionRequest{
+				CreateTransactionRequest: &CreateTransactionRequest{
 					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
 					TransactionRequest: TransactionRequest{
 						TransactionType: TransactionTypeAuthOnly,
@@ -163,7 +163,7 @@ func TestBuildAuthRequest(t *testing.T) {
 			"L2L3 Data",
 			baseL2L3,
 			&Request{
-				CreateTransactionRequest: CreateTransactionRequest{
+				CreateTransactionRequest: &CreateTransactionRequest{
 					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
 					TransactionRequest: TransactionRequest{
 						TransactionType: TransactionTypeAuthOnly,
@@ -218,7 +218,7 @@ func TestBuildAuthRequest(t *testing.T) {
 			"L2L3 Data Multiple items",
 			baseL2L3MultipleItems,
 			&Request{
-				CreateTransactionRequest: CreateTransactionRequest{
+				CreateTransactionRequest: &CreateTransactionRequest{
 					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
 					TransactionRequest: TransactionRequest{
 						TransactionType: TransactionTypeAuthOnly,
@@ -273,7 +273,7 @@ func TestBuildAuthRequest(t *testing.T) {
 			"Basic Auth Request with customer IP",
 			withCustomerIP,
 			&Request{
-				CreateTransactionRequest: CreateTransactionRequest{
+				CreateTransactionRequest: &CreateTransactionRequest{
 					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
 					TransactionRequest: TransactionRequest{
 						TransactionType: TransactionTypeAuthOnly,
@@ -316,7 +316,7 @@ func TestBuildAuthRequest(t *testing.T) {
 				MerchantOrderReference:     base.MerchantOrderReference,
 			},
 			&Request{
-				CreateTransactionRequest: CreateTransactionRequest{
+				CreateTransactionRequest: &CreateTransactionRequest{
 					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
 					TransactionRequest: TransactionRequest{
 						TransactionType: TransactionTypeAuthOnly,
@@ -364,7 +364,7 @@ func TestBuildCaptureRequest(t *testing.T) {
 			"Basic Capture Request",
 			base,
 			&Request{
-				CreateTransactionRequest: CreateTransactionRequest{
+				CreateTransactionRequest: &CreateTransactionRequest{
 					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
 					TransactionRequest: TransactionRequest{
 						TransactionType:  TransactionTypePriorAuthCapture,
@@ -398,7 +398,7 @@ func TestBuildVoidRequest(t *testing.T) {
 			"Basic Void Request",
 			base,
 			&Request{
-				CreateTransactionRequest: CreateTransactionRequest{
+				CreateTransactionRequest: &CreateTransactionRequest{
 					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
 					TransactionRequest: TransactionRequest{
 						TransactionType:  TransactionTypeVoid,
@@ -438,7 +438,7 @@ func TestBuildRefundRequest(t *testing.T) {
 				"Basic Refund Request",
 				base,
 				&Request{
-					CreateTransactionRequest: CreateTransactionRequest{
+					CreateTransactionRequest: &CreateTransactionRequest{
 						MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
 						TransactionRequest: TransactionRequest{
 							TransactionType:  TransactionTypeRefund,

--- a/gateways/authorizenet/test_data/transactionDetailsErrorResponse.json
+++ b/gateways/authorizenet/test_data/transactionDetailsErrorResponse.json
@@ -1,0 +1,11 @@
+{
+  "messages": {
+    "resultCode": "Error",
+    "message": [
+      {
+        "code": "E00040",
+        "text": "The record cannot be found."
+      }
+    ]
+  }
+}

--- a/gateways/authorizenet/test_data/transactionDetailsSuccessResponse.json
+++ b/gateways/authorizenet/test_data/transactionDetailsSuccessResponse.json
@@ -1,0 +1,74 @@
+{
+  "transaction": {
+    "transId": "40116993894",
+    "submitTimeUTC": "2023-03-21T20:01:31.243Z",
+    "submitTimeLocal": "2023-03-21T13:01:31.243",
+    "transactionType": "authOnlyTransaction",
+    "transactionStatus": "settledSuccessfully",
+    "responseCode": 1,
+    "responseReasonCode": 1,
+    "responseReasonDescription": "Approval",
+    "authCode": "6UBJKU",
+    "AVSResponse": "Y",
+    "cardCodeResponse": "P",
+    "batch": {
+      "batchId": "13855989",
+      "settlementTimeUTC": "2023-03-22T03:40:34.663Z",
+      "settlementTimeLocal": "2023-03-21T20:40:34.663",
+      "settlementState": "settledSuccessfully"
+    },
+    "order": {
+      "invoiceNumber": "9006052827063014",
+      "discountAmount": 0,
+      "taxIsAfterDiscount": false
+    },
+    "authAmount": 100.5,
+    "settleAmount": 100.5,
+    "taxExempt": false,
+    "payment": {
+      "creditCard": {
+        "cardNumber": "XXXX1111",
+        "expirationDate": "XXXX",
+        "cardType": "Visa"
+      }
+    },
+    "customer": {
+      "email": "pansetwar@bolt.com"
+    },
+    "billTo": {
+      "phoneNumber": "13126470579",
+      "firstName": "Abhishek",
+      "lastName": "Tidke",
+      "address": "21150 N Tatum Blvd Apt 2088",
+      "city": "Phoenix",
+      "state": "Arizona",
+      "zip": "85050",
+      "country": "US"
+    },
+    "shipTo": {
+      "firstName": "Abhishek",
+      "lastName": "Tidke",
+      "address": "21150 N Tatum Blvd Apt 2088",
+      "city": "Phoenix",
+      "state": "Arizona",
+      "zip": "85050",
+      "country": "US"
+    },
+    "recurringBilling": false,
+    "customerIP": "70.176.143.138",
+    "product": "Card Not Present",
+    "marketType": "eCommerce",
+    "networkTransId": "L49LOS1DVBGDNPKEVZG3NOG",
+    "authorizationIndicator": "pre"
+  },
+  "messages": {
+    "resultCode": "Ok",
+    "message": [
+      {
+        "code": "I00001",
+        "text": "Successful."
+      }
+    ]
+  }
+}
+

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -92,7 +92,7 @@ const expirationDateXXXX = "XXXX"
 
 // Request contains a createTransactionRequest for authorizations
 type Request struct {
-	CreateTransactionRequest     CreateTransactionRequest     `json:"createTransactionRequest,omitempty"`
+	CreateTransactionRequest     CreateTransactionRequest     `json:"createTransactionRequest"`
 	GetTransactionDetailsRequest GetTransactionDetailsRequest `json:"getTransactionDetailsRequest,omitempty"`
 }
 

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -217,7 +217,7 @@ type Order struct {
 // Response is a generic Auth.net response
 type Response struct {
 	TransactionResponse TransactionResponse `json:"transactionResponse"`
-	Transaction         Transaction         `json:"transaction,omitempty"`
+	Transaction         *Transaction        `json:"transaction,omitempty"`
 	RefID               string              `json:"refId"`
 	Messsages           Messages            `json:"messages"`
 }

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -92,7 +92,7 @@ const expirationDateXXXX = "XXXX"
 
 // Request contains a createTransactionRequest for authorizations
 type Request struct {
-	CreateTransactionRequest     CreateTransactionRequest     `json:"createTransactionRequest"`
+	CreateTransactionRequest     CreateTransactionRequest     `json:"createTransactionRequest,omitempty"`
 	GetTransactionDetailsRequest GetTransactionDetailsRequest `json:"getTransactionDetailsRequest,omitempty"`
 }
 

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -92,7 +92,14 @@ const expirationDateXXXX = "XXXX"
 
 // Request contains a createTransactionRequest for authorizations
 type Request struct {
-	CreateTransactionRequest CreateTransactionRequest `json:"createTransactionRequest"`
+	CreateTransactionRequest     CreateTransactionRequest     `json:"createTransactionRequest,omitempty"`
+	GetTransactionDetailsRequest GetTransactionDetailsRequest `json:"getTransactionDetailsRequest,omitempty"`
+}
+
+// GetTransactionDetailsRequest contains a transaction ID for fetching transaction details
+type GetTransactionDetailsRequest struct {
+	MerchantAuthentication MerchantAuthentication `json:"merchantAuthentication"`
+	TransID                string                 `json:"transId"`
 }
 
 // CreateTransactionRequest specifies the merchant authentication to be used for request as well as transaction
@@ -210,8 +217,15 @@ type Order struct {
 // Response is a generic Auth.net response
 type Response struct {
 	TransactionResponse TransactionResponse `json:"transactionResponse"`
+	Transaction         Transaction         `json:"transaction"`
 	RefID               string              `json:"refId"`
 	Messsages           Messages            `json:"messages"`
+}
+
+// Transaction describes the transaction details
+type Transaction struct {
+	TransID string   `json:"transId"`
+	Payment *Payment `json:"payment,omitempty"`
 }
 
 // TransactionResponse contains the information from issuer about AVS, CVV and whether or not authorization was successful

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -92,14 +92,14 @@ const expirationDateXXXX = "XXXX"
 
 // Request contains a createTransactionRequest for authorizations
 type Request struct {
-	CreateTransactionRequest     CreateTransactionRequest     `json:"createTransactionRequest,omitempty"`
-	GetTransactionDetailsRequest GetTransactionDetailsRequest `json:"getTransactionDetailsRequest,omitempty"`
+	CreateTransactionRequest     *CreateTransactionRequest     `json:"createTransactionRequest,omitempty"`
+	GetTransactionDetailsRequest *GetTransactionDetailsRequest `json:"getTransactionDetailsRequest,omitempty"`
 }
 
 // GetTransactionDetailsRequest contains a transaction ID for fetching transaction details
 type GetTransactionDetailsRequest struct {
-	MerchantAuthentication MerchantAuthentication `json:"merchantAuthentication"`
-	TransID                string                 `json:"transId"`
+	MerchantAuthentication MerchantAuthentication `json:"merchantAuthentication,omitempty"`
+	TransID                string                 `json:"transId,omitempty"`
 }
 
 // CreateTransactionRequest specifies the merchant authentication to be used for request as well as transaction

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -217,14 +217,14 @@ type Order struct {
 // Response is a generic Auth.net response
 type Response struct {
 	TransactionResponse TransactionResponse `json:"transactionResponse"`
-	Transaction         Transaction         `json:"transaction"`
+	Transaction         Transaction         `json:"transaction,omitempty"`
 	RefID               string              `json:"refId"`
 	Messsages           Messages            `json:"messages"`
 }
 
 // Transaction describes the transaction details
 type Transaction struct {
-	TransID string   `json:"transId"`
+	TransID string   `json:"transId,omitempty"`
 	Payment *Payment `json:"payment,omitempty"`
 }
 

--- a/integration-tests/authorizenet_test.go
+++ b/integration-tests/authorizenet_test.go
@@ -240,3 +240,24 @@ func TestAuthNetAuthCaptureRefund(t *testing.T) {
 		t.Error("Resulting refund should have been successful")
 	}
 }
+
+// TestAuthNetGetTransactionDetails
+// This should successfully fetch transaction details from Authorize.net
+func TestAuthNetGetTransactionDetails(t *testing.T) {
+	client := authorizenet.NewClient(getEnv("AUTH_NET_LOGIN_ID"), getEnv("AUTH_NET_TXN_KEY"), common.Sandbox)
+	transactionDetailsRequest := &sleet.TransactionDetailsRequest{
+		TransactionReference: "40116993894",
+	}
+	transactionDetailsResponse, err := client.GetTransactionDetails(transactionDetailsRequest)
+	if err != nil {
+		t.Error("Transaction Details request should not have failed")
+	}
+
+	if transactionDetailsResponse.ResultCode != string(authorizenet.ResultCodeOK) {
+		t.Error("Transaction details request should have been successful")
+	}
+
+	if transactionDetailsResponse.CardNumber == "" {
+		t.Error("Card Number should not be empty")
+	}
+}

--- a/integration-tests/authorizenet_test.go
+++ b/integration-tests/authorizenet_test.go
@@ -245,6 +245,8 @@ func TestAuthNetAuthCaptureRefund(t *testing.T) {
 // This should successfully fetch transaction details from Authorize.net
 func TestAuthNetGetTransactionDetails(t *testing.T) {
 	client := authorizenet.NewClient(getEnv("AUTH_NET_LOGIN_ID"), getEnv("AUTH_NET_TXN_KEY"), common.Sandbox)
+	fmt.Println("Login ID: ", getEnv("AUTH_NET_LOGIN_ID"))
+	fmt.Println("TXN Key: ", getEnv("AUTH_NET_TXN_KEY"))
 	transactionDetailsRequest := &sleet.TransactionDetailsRequest{
 		TransactionReference: "40116993894",
 	}

--- a/integration-tests/authorizenet_test.go
+++ b/integration-tests/authorizenet_test.go
@@ -245,10 +245,19 @@ func TestAuthNetAuthCaptureRefund(t *testing.T) {
 // This should successfully fetch transaction details from Authorize.net
 func TestAuthNetGetTransactionDetails(t *testing.T) {
 	client := authorizenet.NewClient(getEnv("AUTH_NET_LOGIN_ID"), getEnv("AUTH_NET_TXN_KEY"), common.Sandbox)
-	fmt.Println("Login ID: ", getEnv("AUTH_NET_LOGIN_ID"))
-	fmt.Println("TXN Key: ", getEnv("AUTH_NET_TXN_KEY"))
+	authRequest := sleet_testing.BaseAuthorizationRequestWithEmailPhoneNumber()
+	authRequest.Amount.Amount = int64(randomdata.Number(100))
+	auth, err := client.Authorize(authRequest)
+	if err != nil {
+		t.Error("Authorize request should not have failed")
+	}
+
+	if !auth.Success {
+		t.Error("Resulting auth should have been successful")
+	}
+
 	transactionDetailsRequest := &sleet.TransactionDetailsRequest{
-		TransactionReference: "40116993894",
+		TransactionReference: auth.TransactionReference,
 	}
 	transactionDetailsResponse, err := client.GetTransactionDetails(transactionDetailsRequest)
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -192,6 +192,16 @@ type RefundResponse struct {
 	ErrorCode            *string
 }
 
+// TransactionDetailsRequest for fetching a transaction's details
+type TransactionDetailsRequest struct {
+	TransactionReference string
+}
+
+// TransactionDetailsResponse indicating the transaction details. Currently, only the last 4 digits of credit card is returned.
+type TransactionDetailsResponse struct {
+	CardNumber string
+}
+
 // GetHTTPResponseHeader returns the http response headers specified in the given options.
 func GetHTTPResponseHeader(options map[string]interface{}, httpResp http.Response) http.Header {
 	var responseHeader http.Header

--- a/types.go
+++ b/types.go
@@ -199,6 +199,7 @@ type TransactionDetailsRequest struct {
 
 // TransactionDetailsResponse indicating the transaction details. Currently, only the last 4 digits of credit card is returned.
 type TransactionDetailsResponse struct {
+	ResultCode string
 	CardNumber string
 }
 


### PR DESCRIPTION
Update Authorize Net to support Google Pay Refunds. Authorize Net requires last 4 digits of credit card number for all refunds. We don't currently store this for auth.net Google Pay transactions, however we have the ability to fetch this from auth net via api(getTransactionDetails). This PR fetches the last4 from getTransactionDetails and populates the CC number in the refund request

Related bug: https://app.asana.com/0/1200616417881435/1204243318709223/f

Thread: https://boltpay.slack.com/archives/C03U3T92Y8Z/p1680433093558869