### PR TITLE
Add additional metadata to cybersource auth response

### DIFF
--- a/gateways/cybersource/cybersource.go
+++ b/gateways/cybersource/cybersource.go
@@ -114,6 +114,8 @@ func (client *CybersourceClient) AuthorizeWithContext(ctx context.Context, reque
 		response.CvvResult = translateCvv(cybersourceResponse.ProcessorInformation.CardVerification.ResultCode)
 		response.CvvResultRaw = cybersourceResponse.ProcessorInformation.CardVerification.ResultCode
 		response.ExternalTransactionID = cybersourceResponse.ProcessorInformation.TransactionID
+		response.Metadata[sleet.ApprovalCodeMetadata] = cybersourceResponse.ProcessorInformation.ApprovalCode
+		response.Metadata[sleet.ResponseCodeMetadata] = cybersourceResponse.ProcessorInformation.ResponseCode
 	}
 	return response, nil
 }

--- a/gateways/cybersource/cybersource.go
+++ b/gateways/cybersource/cybersource.go
@@ -114,10 +114,16 @@ func (client *CybersourceClient) AuthorizeWithContext(ctx context.Context, reque
 		response.CvvResult = translateCvv(cybersourceResponse.ProcessorInformation.CardVerification.ResultCode)
 		response.CvvResultRaw = cybersourceResponse.ProcessorInformation.CardVerification.ResultCode
 		response.ExternalTransactionID = cybersourceResponse.ProcessorInformation.TransactionID
-		response.Metadata[sleet.ApprovalCodeMetadata] = cybersourceResponse.ProcessorInformation.ApprovalCode
-		response.Metadata[sleet.ResponseCodeMetadata] = cybersourceResponse.ProcessorInformation.ResponseCode
+		response.Metadata = buildResponseMetadata(*cybersourceResponse.ProcessorInformation)
 	}
 	return response, nil
+}
+
+func buildResponseMetadata(processorInformation ProcessorInformation) map[string]string {
+	metadata := make(map[string]string)
+	metadata[sleet.ApprovalCodeMetadata] = processorInformation.ApprovalCode
+	metadata[sleet.ResponseCodeMetadata] = processorInformation.ResponseCode
+	return metadata
 }
 
 // Capture captures an authorized payment through CyberSource. If successful, the capture response will be returned.

--- a/types.go
+++ b/types.go
@@ -116,7 +116,9 @@ type AuthorizationRequest struct {
 }
 
 const (
-	AuthCodeMetadata string = "authCode"
+	AuthCodeMetadata     string = "authCode"
+	ApprovalCodeMetadata string = "approvalCode"
+	ResponseCodeMetadata string = "responseCode"
 )
 
 // AuthorizationResponse is a generic response returned back to client after data massaging from PsP Response


### PR DESCRIPTION
Add `processorInformation.approvalCode` and `processorInformation.responseCode` to cybersource auth response.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204920789048078