### PR TITLE
Add merchant order reference to Paypal Payflow auth request

### DIFF
--- a/gateways/paypalpayflow/paypalpayflow.go
+++ b/gateways/paypalpayflow/paypalpayflow.go
@@ -63,6 +63,7 @@ func (client *PaypalPayflowClient) sendRequest(ctx context.Context, request *Req
 		"BILLTOCOUNTRY":   request.BillToCountry,
 		"CARDONFILE":      request.CardOnFile,
 		"TXID":            request.TxID,
+		"COMMENT1":        request.Comment1,
 	}
 	for k, v := range fields {
 		switch v := v.(type) {

--- a/gateways/paypalpayflow/request_builder.go
+++ b/gateways/paypalpayflow/request_builder.go
@@ -54,6 +54,7 @@ func buildAuthorizeParams(request *sleet.AuthorizationRequest) *Request {
 		BillToCountry:      request.BillingAddress.CountryCode,
 		CardOnFile:         CardOnFile,
 		TxID:               request.PreviousExternalTransactionID,
+		Comment1:           &request.MerchantOrderReference,
 	}
 }
 

--- a/gateways/paypalpayflow/request_builders_test.go
+++ b/gateways/paypalpayflow/request_builders_test.go
@@ -58,6 +58,7 @@ func TestBuildAuthRequest(t *testing.T) {
 				BillToStreet:       visaBase.BillingAddress.StreetAddress1,
 				BillToStreet2:      visaBase.BillingAddress.StreetAddress2,
 				BillToCountry:      visaBase.BillingAddress.CountryCode,
+				Comment1:           &visaBase.MerchantOrderReference,
 			},
 		},
 		{
@@ -78,6 +79,7 @@ func TestBuildAuthRequest(t *testing.T) {
 				BillToStreet:       visaBase.BillingAddress.StreetAddress1,
 				BillToStreet2:      visaBase.BillingAddress.StreetAddress2,
 				BillToCountry:      visaBase.BillingAddress.CountryCode,
+				Comment1:           &visaBase.MerchantOrderReference,
 			},
 		},
 		{
@@ -98,6 +100,7 @@ func TestBuildAuthRequest(t *testing.T) {
 				BillToStreet:       visaBase.BillingAddress.StreetAddress1,
 				BillToStreet2:      visaBase.BillingAddress.StreetAddress2,
 				BillToCountry:      visaBase.BillingAddress.CountryCode,
+				Comment1:           &visaBase.MerchantOrderReference,
 			},
 		},
 		{
@@ -118,6 +121,7 @@ func TestBuildAuthRequest(t *testing.T) {
 				BillToStreet:       visaBase.BillingAddress.StreetAddress1,
 				BillToStreet2:      visaBase.BillingAddress.StreetAddress2,
 				BillToCountry:      visaBase.BillingAddress.CountryCode,
+				Comment1:           &visaBase.MerchantOrderReference,
 			},
 		},
 	}

--- a/gateways/paypalpayflow/types.go
+++ b/gateways/paypalpayflow/types.go
@@ -42,6 +42,7 @@ type Request struct {
 	BillToCountry      *string // country code
 	CardOnFile         *string
 	TxID               *string
+	Comment1           *string // merchant order reference
 }
 
 type Response map[string]string


### PR DESCRIPTION
Use the COMMENT1 field for merchant order reference in paypal payflow auth request.

