### PR TITLE
[Authorize.net] Various corrections to L2/L3 data inputs

### DIFF
--- a/gateways/authorizenet/request_builders_test.go
+++ b/gateways/authorizenet/request_builders_test.go
@@ -30,6 +30,15 @@ func TestBuildAuthRequest(t *testing.T) {
 	baseL2L3MultipleItems.Level3Data = sleet_testing.BaseLevel3DataMultipleItem()
 	baseL2L3MultipleItems.ShippingAddress = baseL2L3MultipleItems.BillingAddress
 
+	l2l3EmptyFields := sleet_testing.BaseAuthorizationRequest()
+	l2l3EmptyFields.MerchantOrderReference = randomdata.Alphanumeric(InvoiceNumberMaxLength + 5)
+	l2l3EmptyFields.Level3Data = sleet_testing.BaseLevel3DataMultipleItem()
+	l2l3EmptyFields.ShippingAddress = baseL2L3MultipleItems.BillingAddress
+	for i := range l2l3EmptyFields.Level3Data.LineItems {
+		l2l3EmptyFields.Level3Data.LineItems[i].ProductCode = ""
+		l2l3EmptyFields.Level3Data.LineItems[i].Description = ""
+	}
+
 	withCustomerIP := sleet_testing.BaseAuthorizationRequestWithEmailPhoneNumber()
 	withCustomerIP.MerchantOrderReference = randomdata.Alphanumeric(InvoiceNumberMaxLength + 5)
 	customerIP := common.SPtr("192.168.0.1")
@@ -187,14 +196,14 @@ func TestBuildAuthRequest(t *testing.T) {
 						Order: &Order{
 							InvoiceNumber: baseL2L3.MerchantOrderReference[:InvoiceNumberMaxLength],
 						},
-						LineItem: json.RawMessage(`{"lineItem":{"itemId":"cmd","name":"abc","description":"pot","quantity":"2","unitPrice":"500"}}`),
-						Tax: &Tax{
+						LineItem: json.RawMessage(`{"lineItem":{"itemId":"abc","name":"pot","description":"pot","quantity":"2","unitPrice":"500"}}`),
+						Tax: &ExtendedAmount{
 							Amount: "100",
 						},
-						Duty: &Tax{
+						Duty: &ExtendedAmount{
 							Amount: "400",
 						},
-						Shipping: &Tax{
+						Shipping: &ExtendedAmount{
 							Amount: "300",
 						},
 						Customer: &Customer{
@@ -242,14 +251,69 @@ func TestBuildAuthRequest(t *testing.T) {
 						Order: &Order{
 							InvoiceNumber: baseL2L3MultipleItems.MerchantOrderReference[:InvoiceNumberMaxLength],
 						},
-						LineItem: json.RawMessage(`{"lineItem":{"itemId":"cmd","name":"abc","description":"pot","quantity":"2","unitPrice":"500"},"lineItem":{"itemId":"321","name":"123","description":"vase","quantity":"5","unitPrice":"1000"}}`),
-						Tax: &Tax{
+						LineItem: json.RawMessage(`{"lineItem":{"itemId":"abc","name":"pot","description":"pot","quantity":"2","unitPrice":"500"},"lineItem":{"itemId":"123","name":"vase","description":"vase","quantity":"5","unitPrice":"1000"}}`),
+						Tax: &ExtendedAmount{
 							Amount: "100",
 						},
-						Duty: &Tax{
+						Duty: &ExtendedAmount{
 							Amount: "400",
 						},
-						Shipping: &Tax{
+						Shipping: &ExtendedAmount{
+							Amount: "300",
+						},
+						Customer: &Customer{
+							Id: "customer",
+						},
+						ShippingAddress: &ShippingAddress{
+							FirstName: "Bolt",
+							LastName:  "Checkout",
+							Company:   common.SafeStr(base.BillingAddress.Company),
+							Address:   base.BillingAddress.StreetAddress1,
+							City:      base.BillingAddress.Locality,
+							State:     base.BillingAddress.RegionCode,
+							Zip:       base.BillingAddress.PostalCode,
+							Country:   base.BillingAddress.CountryCode,
+						},
+					},
+				},
+			},
+		},
+		{
+			"L2L3 Data Empty Fields",
+			l2l3EmptyFields,
+			&Request{
+				CreateTransactionRequest: &CreateTransactionRequest{
+					MerchantAuthentication: MerchantAuthentication{Name: "MerchantName", TransactionKey: "Key"},
+					TransactionRequest: TransactionRequest{
+						TransactionType: TransactionTypeAuthOnly,
+						Amount:          &amount,
+						Payment: &Payment{
+							CreditCard: &CreditCard{
+								CardNumber:     "4111111111111111",
+								ExpirationDate: "2023-10",
+								CardCode:       base.CreditCard.CVV,
+							},
+						},
+						BillingAddress: &BillingAddress{
+							FirstName: "Bolt",
+							LastName:  "Checkout",
+							Address:   base.BillingAddress.StreetAddress1,
+							City:      base.BillingAddress.Locality,
+							State:     base.BillingAddress.RegionCode,
+							Zip:       base.BillingAddress.PostalCode,
+							Country:   base.BillingAddress.CountryCode,
+						},
+						Order: &Order{
+							InvoiceNumber: l2l3EmptyFields.MerchantOrderReference[:InvoiceNumberMaxLength],
+						},
+						LineItem: json.RawMessage(`{"lineItem":{"itemId":"1","name":"1","quantity":"2","unitPrice":"500"},"lineItem":{"itemId":"2","name":"2","quantity":"5","unitPrice":"1000"}}`),
+						Tax: &ExtendedAmount{
+							Amount: "100",
+						},
+						Duty: &ExtendedAmount{
+							Amount: "400",
+						},
+						Shipping: &ExtendedAmount{
 							Amount: "300",
 						},
 						Customer: &Customer{

--- a/gateways/authorizenet/types.go
+++ b/gateways/authorizenet/types.go
@@ -132,9 +132,9 @@ type TransactionRequest struct {
 	Order            *Order          `json:"order,omitempty"`
 	LineItem         json.RawMessage `json:"lineItems,omitempty"` // this is really a repeating LineItem, but authorize.net expects it in object not array
 	// since not valid json, just going to represent as JSON string
-	Tax             *Tax             `json:"tax,omitempty"`
-	Duty            *Tax             `json:"duty,omitempty"`
-	Shipping        *Tax             `json:"shipping,omitempty"`
+	Tax             *ExtendedAmount  `json:"tax,omitempty"`
+	Duty            *ExtendedAmount  `json:"duty,omitempty"`
+	Shipping        *ExtendedAmount  `json:"shipping,omitempty"`
 	Customer        *Customer        `json:"customer,omitempty"`
 	BillingAddress  *BillingAddress  `json:"billTo,omitempty"`
 	ShippingAddress *ShippingAddress `json:"shipTo,omitempty"`
@@ -142,14 +142,15 @@ type TransactionRequest struct {
 }
 
 type LineItem struct {
-	ItemId      string `json:"itemId,omitempty"`
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
-	Quantity    string `json:"quantity,omitempty"`
-	UnitPrice   string `json:"unitPrice,omitempty"`
+	ItemId      string `json:"itemId,omitempty"`      // min length = 1, max length = 31
+	Name        string `json:"name,omitempty"`        // min length = 1, max length = 31
+	Description string `json:"description,omitempty"` // max length = 255
+	Quantity    string `json:"quantity,omitempty"`    // decimal as string, max decimal precision = 4
+	UnitPrice   string `json:"unitPrice,omitempty"`   // decimal as string, max decimal precision = 4
+	Taxable     string `json:"taxable,omitempty"`     // boolean as string
 }
 
-type Tax struct {
+type ExtendedAmount struct {
 	Amount      string `json:"amount,omitempty"`
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`


### PR DESCRIPTION
Our L2/L3 Line Item inputs were not fully compliant with Authorize.net's specification.

Firstly, we were sending the incorrect item fields. CommodityCode was used for the item ID when instead ProductCode should be used. And ProductCode was used for the name when Description should be used.

Next, Authorize.net requires an item ID and a name on every item. Some cart items may not have a product code or description added. To facilitate successful auths when limited data is available, we will use the item index as a substitute for item ID, and the item ID as substitute for the item name. There is precedent for adding this logic for other L2/L3-supported processors.

Lastly, I renamed some types and fields and added notes regarding the specific requirements for each field from Authorize.net's documentation.