### PR TITLE
Disable automatic integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,13 @@ jobs:
               -coverpkg="$GOCOVER_LIST"  \
               -coverprofile=unit_coverage.profile \
               $(go list ./... | grep -v integration-tests)
-      - run:
-          name: Integration Test
-          command: |
-            cd integration-tests
-            go test -v
+# Turn off Integration tests.
+# This repo is going to be shelved, so let's not block commits to depend on an unmaintained test environment.
+#      - run:
+#          name: Integration Test
+#          command: |
+#            cd integration-tests
+#            go test -v
       - run:
           name: Install goimports
           command: |


### PR DESCRIPTION
### Description

The integration test environment is currently not maintained. Remove the build step to run them so that commits won't be blocked by these tests.
